### PR TITLE
Check request attribute before convert to other value type

### DIFF
--- a/cmd/res/example/configuration.toml
+++ b/cmd/res/example/configuration.toml
@@ -87,11 +87,11 @@ Parameters = "[{\"OperationMode\": \"Auto\"},{\"FanSpeed\": \"Med\"},{\"Temperat
 Schedule = "10sec-schedule"
   [ScheduleEvents.Addressable]
   HTTPMethod = "Put"
-  Path = "/api/v1/device/name/Modbus TCP test device/SetHVACValues"
+  Path = "/api/v1/device/name/Modbus TCP test device/HVACValues"
 
 [[ScheduleEvents]]
 Name = "Set the Switch"
-Parameters = "[{\"Switch\": \"ON\"}]"
+Parameters = "[{\"SwitchA\": \"ON\"},{\"SwitchB\": \"ON\"}]"
 Schedule = "10sec-schedule"
   [ScheduleEvents.Addressable]
   HTTPMethod = "Put"
@@ -102,9 +102,9 @@ Name = "5sec-schedule"
 Frequency = "PT5S"
 
 [[ScheduleEvents]]
-Name = "Read OperationMode"
+Name = "Read Values"
 Schedule = "5sec-schedule"
   [ScheduleEvents.Addressable]
   HTTPMethod = "GET"
-  Path = "/api/v1/device/name/Modbus TCP test device/OperationMode"
+  Path = "/api/v1/device/name/Modbus TCP test device/Values"
 

--- a/cmd/res/example/modbus.test.device.profile.yml
+++ b/cmd/res/example/modbus.test.device.profile.yml
@@ -8,13 +8,24 @@ description: "CoolMasterNet is an unique communication bridge that seamlessly co
 
 deviceResources:
 -
-  name: "Switch"
+  name: "SwitchA"
   description: "On/Off , 0-OFF 1-ON"
   attributes:
     { primaryTable: "COILS", startingAddress: "1" }
   properties:
     value:
-      { type: "BOOL", readWrite: "RW", size: "1", scale: "1", minimum: "0", maximum: "1", defaultValue: "0"}
+      { type: "BOOL", readWrite: "RW", scale: "1", minimum: "0", maximum: "1", defaultValue: "0"}
+    units:
+      { type: "String", readWrite: "R", defaultValue: "On/Off"}
+
+-
+  name: "SwitchB"
+  description: "On/Off , 0-OFF 1-ON"
+  attributes:
+    { primaryTable: "COILS", startingAddress: "15" }
+  properties:
+    value:
+      { type: "BOOL", readWrite: "RW", scale: "1", minimum: "0", maximum: "1", defaultValue: "0"}
     units:
       { type: "String", readWrite: "R", defaultValue: "On/Off"}
 
@@ -25,7 +36,7 @@ deviceResources:
     { primaryTable: "HOLDING_REGISTERS", startingAddress: "2" }
   properties:
     value:
-      { type: "INT16", readWrite: "RW", size: "1", scale: "1", minimum: "0", maximum: "11", defaultValue: "0"}
+      { type: "INT16", readWrite: "RW", scale: "1", minimum: "0", maximum: "11", defaultValue: "0"}
     units:
       { type: "String", readWrite: "R", defaultValue: "Operation Mode"}
 
@@ -36,7 +47,7 @@ deviceResources:
     { primaryTable: "HOLDING_REGISTERS", startingAddress: "3" }
   properties:
     value:
-      { type: "INT32", readWrite: "RW", size: "1", scale: "1", minimum: "0", maximum: "9", defaultValue: "0"}
+      { type: "INT32", readWrite: "RW", scale: "1", minimum: "0", maximum: "9", defaultValue: "0"}
     units:
       { type: "String", readWrite: "R", defaultValue: "Fan Speed"}
 
@@ -47,7 +58,7 @@ deviceResources:
     { primaryTable: "INPUT_REGISTERS", startingAddress: "4" }
   properties:
     value:
-      { type: "FLOAT32", readWrite: "R", size: "0.1", scale: "1"}
+      { type: "FLOAT32", readWrite: "R", scale: "1"}
     units:
       { type: "String", readWrite: "R", defaultValue: "degrees Celsius"}
 
@@ -58,7 +69,7 @@ deviceResources:
     { primaryTable: "HOLDING_REGISTERS", startingAddress: "5" }
   properties:
     value:
-      { type: "FLOAT64", readWrite: "RW", size: "1", scale: "0.1", defaultValue: "21"}
+      { type: "FLOAT64", readWrite: "RW", scale: "0.1"}
     units:
       { type: "String", readWrite: "R", defaultValue: "degrees Celsius"}
 
@@ -66,43 +77,31 @@ deviceResources:
 resources:
 -
   name: "Switch"
-  set:
-  - { index: "1", operation: "set", object: "Switch", parameter: "Switch", property: "value" ,mappings: { "OFF":"true","ON":"false"}}
-
--
-  name: "OperationMode"
   get:
-  - { index: "1", operation: "get", object: "OperationMode", parameter: "OperationMode", property: "value" ,mappings: { "0":"Cool","1":"Heat","2":"Auto","3":"Dry","4":"HAUX","5":"Fan","6":"HH","8":"VAM Auto","9":"VAM Bypass","10":"VAM Heat","11":"VAM Normal"} }
-
+  - { index: "1", operation: "set", object: "SwitchA", parameter: "SwitchA", property: "value" ,mappings: { "true":"ON","false":"OFF"}}
+  - { index: "2", operation: "set", object: "SwitchB", parameter: "SwitchB", property: "value" ,mappings: { "true":"ON","false":"OFF"}}
   set:
-  - { index: "1", operation: "set", object: "OperationMode", parameter: "OperationMode", property: "value" ,mappings: { "Cool":"0","Heat":"1","Auto":"2","Dry":"3","HAUX":"4","Fan":"5","HH":"6","VAM Auto":"8","VAM Bypass":"9","VAM Heat":"10","VAM Normal":"11"}}
-
+  - { index: "1", operation: "set", object: "SwitchA", parameter: "SwitchA", property: "value" ,mappings: { "OFF":"false","ON":"true"}}
+  - { index: "1", operation: "set", object: "SwitchB", parameter: "SwitchB", property: "value" ,mappings: { "OFF":"false","ON":"true"}}
 -
-  name: "FanSpeed"
-  set:
-  - { index: "1", operation: "set", object: "FanSpeed", parameter: "FanSpeed", property: "value" ,mappings: { "Low":"0","Med":"1","High":"2","Auto":"3","Top":"4","Very Lo":"5","VAM Super Hi":"7","VAM Lo FreshUp":"8","VAMHiFreshUp":"9"}}
-
--
-  name: "RoomTemperature"
+  name: "Values"
   get:
-  - { index: "1", operation: "get", object: "RoomTemperature", parameter: "RoomTemperature", property: "value" }
-
--
-  name: "Temperature"
-  set:
-  - { index: "1", operation: "set", object: "Temperature", parameter: "Temperature", property: "value" }
-
--
-  name: "GetHVACValues"
-  get:
-  - { index: "1", operation: "get", object: "Switch", parameter: "Switch", property: "value" ,mappings: { "true":"OFF","false":"ON"}}
+  - { index: "1", operation: "get", object: "SwitchA", parameter: "SwitchA", property: "value" ,mappings: { "true":"ON","false":"OFF"}}
   - { index: "2", operation: "get", object: "OperationMode", parameter: "OperationMode", property: "value",mappings: { "0":"Cool","1":"Heat","2":"Auto","3":"Dry","4":"HAUX","5":"Fan","6":"HH","8":"VAM Auto","9":"VAM Bypass","10":"VAM Heat","11":"VAM Normal"} }
   - { index: "3", operation: "get", object: "FanSpeed", parameter: "FanSpeed", property: "value",mappings: { "0":"Low","1":"Med","2":"High","3":"Auto","4":"Top","5":"Very Lo","7":"VAM Super Hi","8":"VAM Lo FreshUp","9":"VAMHiFreshUp"} }
   - { index: "4", operation: "get", object: "RoomTemperature", parameter: "RoomTemperature", property: "value" }
   - { index: "5", operation: "get", object: "Temperature", parameter: "Temperature", property: "value" }
-
+  set:
+  - { index: "1", operation: "set", object: "SwitchA", parameter: "SwitchA", property: "value" ,mappings: { "ON":"true","OFF":"false"}}
+  - { index: "2", operation: "set", object: "OperationMode", parameter: "OperationMode", property: "value",mappings: { "Cool":"0","Heat":"1","Auto":"2","Dry":"3","HAUX":"4","Fan":"5","HH":"6","VAM Auto":"8","VAM Bypass":"9","VAM Heat":"10","VAM Normal":"11"} }
+  - { index: "3", operation: "set", object: "FanSpeed", parameter: "FanSpeed", property: "value",mappings: { "Low":"0","Med":"1","High":"2","Auto":"3","Top":"4","Very Lo":"5","VAM Super Hi":"7","VAM Lo FreshUp":"8","VAMHiFreshUp":"9"} }
+  - { index: "4", operation: "set", object: "Temperature", parameter: "Temperature", property: "value" }
 -
-  name: "SetHVACValues"
+  name: "HVACValues"
+  get:
+  - { index: "1", operation: "get", object: "OperationMode", parameter: "OperationMode", property: "value",mappings: { "0":"Cool","1":"Heat","2":"Auto","3":"Dry","4":"HAUX","5":"Fan","6":"HH","8":"VAM Auto","9":"VAM Bypass","10":"VAM Heat","11":"VAM Normal"} }
+  - { index: "2", operation: "get", object: "FanSpeed", parameter: "FanSpeed", property: "value",mappings: { "0":"Low","1":"Med","2":"High","3":"Auto","4":"Top","5":"Very Lo","7":"VAM Super Hi","8":"VAM Lo FreshUp","9":"VAMHiFreshUp"} }
+  - { index: "3", operation: "get", object: "Temperature", parameter: "Temperature", property: "value" }
   set:
   - { index: "1", operation: "set", object: "OperationMode", parameter: "OperationMode", property: "value",mappings: { "Cool":"0","Heat":"1","Auto":"2","Dry":"3","HAUX":"4","Fan":"5","HH":"6","VAM Auto":"8","VAM Bypass":"9","VAM Heat":"10","VAM Normal":"11"} }
   - { index: "2", operation: "set", object: "FanSpeed", parameter: "FanSpeed", property: "value",mappings: { "Low":"0","Med":"1","High":"2","Auto":"3","Top":"4","Very Lo":"5","VAM Super Hi":"7","VAM Lo FreshUp":"8","VAMHiFreshUp":"9"} }
@@ -111,9 +110,18 @@ resources:
 commands:
 -
   name: "Switch"
+  get:
+    path: "/api/v1/device/{deviceId}/Switch"
+    responses:
+    - code: "200"
+      description: "Get the Switch"
+      expectedValues: ["SwitchA","SwitchB"]
+    - code: "503"
+      description: "service unavailable"
+      expectedValues: []
   put:
     path: "/api/v1/device/{deviceId}/Switch"
-    parameterNames: ["Switch"]
+    parameterNames: ["SwitchA","SwitchB"]
     responses:
     -
       code: "204"
@@ -123,76 +131,46 @@ commands:
       code: "503"
       description: "service unavailable"
       expectedValues: []
-
 -
-  name: "OperationMode"
+  name: "Values"
   get:
-    path: "/api/v1/device/{deviceId}/OperationMode"
-    responses:
-    - code: "200"
-      description: "Get the values from the device"
-      expectedValues: ["OperationMode"]
-    - code: "503"
-      description: "service unavailable"
-      expectedValues: []
-  put:
-    path: "/api/v1/device/{deviceId}/OperationMode"
-    parameterNames: ["OperationMode"]
-    responses:
-    -
-      code: "204"
-      description: "Set the OperationMode"
-      expectedValues: []
-    -
-      code: "503"
-      description: "service unavailable"
-      expectedValues: []
--
-  name: "FanSpeed"
-  put:
-    path: "/api/v1/device/{deviceId}/FanSpeed"
-    parameterNames: ["FanSpeed"]
-    responses:
-    -
-      code: "204"
-      description: "Set the FanSpeed"
-      expectedValues: []
-    -
-      code: "503"
-      description: "service unavailable"
-      expectedValues: []
--
-  name: "Temperature"
-  put:
-    path: "/api/v1/device/{deviceId}/Temperature"
-    parameterNames: ["Temperature"]
-    responses:
-    -
-      code: "204"
-      description: "Set the Temperature"
-      expectedValues: []
-    -
-      code: "503"
-      description: "service unavailable"
-      expectedValues: []
-
--
-  name: "GetHVACValues"
-  get:
-    path: "/api/v1/device/{deviceId}/GetHVACValues"
+    path: "/api/v1/device/{deviceId}/Values"
     responses:
     -
       code: "200"
       description: "Get the values from the device"
-      expectedValues: ["Switch","OperationMode","FanSpeed","RoomTemperature","Temperature"]
+      expectedValues: ["SwitchA","OperationMode","FanSpeed","RoomTemperature","Temperature"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
+  put:
+    path: "/api/v1/device/{deviceId}/Values"
+    parameterNames: ["SwitchA","OperationMode","FanSpeed","Temperature"]
+    responses:
+    -
+      code: "204"
+      description: "Set the HVAC Values"
+      expectedValues: []
     -
       code: "503"
       description: "service unavailable"
       expectedValues: []
 -
-  name: "SetHVACValues"
+  name: "HVACValues"
+  get:
+    path: "/api/v1/device/{deviceId}/HVACValues"
+    responses:
+    -
+      code: "200"
+      description: "Get the HVAC values from the device"
+      expectedValues: ["OperationMode","FanSpeed","Temperature"]
+    -
+      code: "503"
+      description: "service unavailable"
+      expectedValues: []
   put:
-    path: "/api/v1/device/{deviceId}/SetHVACValues"
+    path: "/api/v1/device/{deviceId}/HVACValues"
     parameterNames: ["OperationMode","FanSpeed","Temperature"]
     responses:
     -

--- a/internal/driver/attributechecker.go
+++ b/internal/driver/attributechecker.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"fmt"
+	sdkModel "github.com/edgexfoundry/device-sdk-go/pkg/models"
+)
+
+func checkAttributes(reqs []sdkModel.CommandRequest) error {
+	var err error = nil
+	for _, req := range reqs {
+		attributes := req.DeviceObject.Attributes
+
+		_, err = toString(attributes["primaryTable"])
+		if err != nil {
+			return fmt.Errorf("primaryTable fail to convert interface inoto string: %v", err)
+		}
+
+		_, err = toUint16(attributes["startingAddress"])
+		if err != nil {
+			return fmt.Errorf("startingAddress fail to convert interface inoto unit16: %v", err)
+		}
+
+		_, ok := attributes["isByteSwap"]
+		if ok {
+			_, err = toBool(attributes["isByteSwap"])
+			if err != nil {
+				return fmt.Errorf("isByteSwap fail to convert interface inoto boolean: %v", err)
+			}
+		}
+
+		_, ok = attributes["isWordSwap"]
+		if ok {
+			_, err = toBool(attributes["isWordSwap"])
+			if err != nil {
+				return fmt.Errorf("isWordSwap fail to convert interface inoto boolean: %v", err)
+			}
+		}
+	}
+	return err
+}

--- a/internal/driver/attributechecker_test.go
+++ b/internal/driver/attributechecker_test.go
@@ -1,0 +1,58 @@
+package driver
+
+import (
+	"testing"
+
+	sdkModel "github.com/edgexfoundry/device-sdk-go/pkg/models"
+	"github.com/edgexfoundry/edgex-go/pkg/models"
+)
+
+func TestCheckAttributes(t *testing.T) {
+	requests := []sdkModel.CommandRequest{
+		{
+			DeviceObject: models.DeviceObject{
+				Attributes: map[string]interface{}{
+					"primaryTable":    "HOLDING_REGISTERS",
+					"startingAddress": 1001,
+					"isByteSwap":      "true"},
+			},
+		},
+		{
+			DeviceObject: models.DeviceObject{
+				Attributes: map[string]interface{}{
+					"primaryTable":    "HOLDING_REGISTERS",
+					"startingAddress": "1002",
+					"isByteSwap":      "true"},
+			},
+		},
+	}
+
+	err := checkAttributes(requests)
+	if err != nil {
+		t.Fatalf("Test check attributes failed! Error: %v", err)
+	}
+}
+
+func TestCheckAttributes_fail(t *testing.T) {
+	requests := []sdkModel.CommandRequest{
+		{
+			DeviceObject: models.DeviceObject{
+				Attributes: map[string]interface{}{
+					"startingAddress": 1001,
+					"isByteSwap":      "true"},
+			},
+		},
+		{
+			DeviceObject: models.DeviceObject{
+				Attributes: map[string]interface{}{
+					"startingAddress": "1002",
+					"isByteSwap":      "true"},
+			},
+		},
+	}
+
+	err := checkAttributes(requests)
+	if err == nil {
+		t.Fatalf("Test should be failed!")
+	}
+}

--- a/internal/driver/caster.go
+++ b/internal/driver/caster.go
@@ -1,0 +1,40 @@
+package driver
+
+import (
+	"fmt"
+	"strconv"
+)
+
+func toString(i interface{}) (string, error) {
+	if i == nil {
+		return "", fmt.Errorf("value is undefined")
+	}
+	return fmt.Sprintf("%v", i), nil
+}
+
+func toUint16(i interface{}) (uint16, error) {
+	var val uint16 = 0
+	if i == nil {
+		return val, fmt.Errorf("value is undefined")
+	}
+	stringVal := fmt.Sprintf("%v", i)
+	uint64Val, err := strconv.ParseUint(stringVal, 10, 16)
+	if err != nil {
+		return val, fmt.Errorf("parse to uint16 failed, error: %v", err)
+	}
+	val = uint16(uint64Val)
+	return val, nil
+}
+
+func toBool(i interface{}) (bool, error) {
+	var val = false
+	if i == nil {
+		return val, fmt.Errorf("value is undefined")
+	}
+	stringVal := fmt.Sprintf("%v", i)
+	val, err := strconv.ParseBool(stringVal)
+	if err != nil {
+		return val, fmt.Errorf("parse to bool failed, error: %v", err)
+	}
+	return val, nil
+}

--- a/internal/driver/deviceclient.go
+++ b/internal/driver/deviceclient.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	sdkModel "github.com/edgexfoundry/device-sdk-go/pkg/models"
@@ -65,11 +66,13 @@ func createConnectionInfo(addr models.Addressable) (*ConnectionInfo, error) {
 
 func createCommandInfo(object models.DeviceObject) *CommandInfo {
 	primaryTable, _ := toString(object.Attributes["primaryTable"])
+	primaryTable = strings.ToUpper(primaryTable)
+
 	startingAddress, _ := toUint16(object.Attributes["startingAddress"])
 	startingAddress = startingAddress - 1
 
-	var length = calculateAddressLength(primaryTable, object.Properties.Value.Type)
-	var valueType = object.Properties.Value.Type
+	valueType := strings.ToUpper(object.Properties.Value.Type)
+	length := calculateAddressLength(primaryTable, valueType)
 
 	var isByteSwap = false
 	_, ok := object.Attributes["isByteSwap"]

--- a/internal/driver/deviceclient.go
+++ b/internal/driver/deviceclient.go
@@ -64,28 +64,28 @@ func createConnectionInfo(addr models.Addressable) (*ConnectionInfo, error) {
 }
 
 func createCommandInfo(object models.DeviceObject) *CommandInfo {
-	var primaryTable, _ = object.Attributes["primaryTable"].(string)
-
-	var startingAddress, _ = strconv.Atoi(object.Attributes["startingAddress"].(string))
-	var startingAddressUint16 = uint16(startingAddress - 1)
+	primaryTable, _ := toString(object.Attributes["primaryTable"])
+	startingAddress, _ := toUint16(object.Attributes["startingAddress"])
+	startingAddress = startingAddress - 1
 
 	var length = calculateAddressLength(primaryTable, object.Properties.Value.Type)
-
 	var valueType = object.Properties.Value.Type
 
-	isByteSwap, keyExisted := object.Attributes["isByteSwap"].(bool)
-	if !keyExisted {
-		isByteSwap = false
+	var isByteSwap = false
+	_, ok := object.Attributes["isByteSwap"]
+	if ok {
+		isByteSwap, _ = toBool(object.Attributes["isByteSwap"])
 	}
 
-	isWordSwap, keyExisted := object.Attributes["isWordSwap"].(bool)
-	if !keyExisted {
-		isWordSwap = false
+	var isWordSwap = false
+	_, ok = object.Attributes["isWordSwap"]
+	if ok {
+		isWordSwap, _ = toBool(object.Attributes["isWordSwap"])
 	}
 
 	return &CommandInfo{
 		PrimaryTable:    primaryTable,
-		StartingAddress: startingAddressUint16,
+		StartingAddress: startingAddress,
 		ValueType:       valueType,
 		Length:          length,
 		IsByteSwap:      isByteSwap,

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -30,8 +30,14 @@ func (*Driver) DisconnectDevice(address *models.Addressable) error {
 
 func (d *Driver) HandleReadCommands(addr *models.Addressable, reqs []sdkModel.CommandRequest) ([]*sdkModel.CommandValue, error) {
 	var responses = make([]*sdkModel.CommandValue, len(reqs))
-	var err error
 	var deviceClient DeviceClient
+
+	// Check request's attribute to avoid interface cast error
+	err := checkAttributes(reqs)
+	if err != nil {
+		driver.Logger.Info(fmt.Sprintf("CommandRequest's attribute are invalid. err:%v \n", err))
+		return responses, err
+	}
 
 	// create device client and open connection
 	connectionInfo, err := createConnectionInfo(*addr)
@@ -94,7 +100,13 @@ func (d *Driver) handleReadCommandRequest(deviceClient DeviceClient, req sdkMode
 
 func (d *Driver) HandleWriteCommands(addr *models.Addressable, reqs []sdkModel.CommandRequest, params []*sdkModel.CommandValue) error {
 	var deviceClient DeviceClient
-	var err error
+
+	// Check request's attribute to avoid interface cast error
+	err := checkAttributes(reqs)
+	if err != nil {
+		driver.Logger.Info(fmt.Sprintf("CommandRequest's attribute are invalid. err:%v \n", err))
+		return err
+	}
 
 	// create device client and open connection
 	connectionInfo, err := createConnectionInfo(*addr)


### PR DESCRIPTION
Fix #9 
Add an attribute checker to make sure all requests attribute are valid and then device-modbus can parse interface safely.