### PR TITLE
Add initial snap packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,11 @@ vendor/
 cmd/device-modbus
 glide.lock
 go.sum
+
+# snap files
+*.snap
+*.assert
+prime/
+stage/
+parts/
+squashfs-root/

--- a/snap/hooks/configure
+++ b/snap/hooks/configure
@@ -1,0 +1,4 @@
+#!/bin/bash -e
+
+# empty configure hook to allow snap configuration with snap set / snapctl set
+# to work

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -1,0 +1,24 @@
+#!/bin/bash -e
+
+# get the values of $SNAP_DATA and $SNAP using the current symlink instead of
+# the default behavior which has the revision hard-coded, which breaks after
+# a refresh
+SNAP_DATA_CURRENT=${SNAP_DATA/%$SNAP_REVISION/current}
+SNAP_CURRENT=${SNAP/%$SNAP_REVISION/current}
+
+# install all the config files from $SNAP/config/SERVICE/res/configuration.toml 
+# into $SNAP_DATA/config
+mkdir -p "$SNAP_DATA/config"
+if [ ! -f "$SNAP_DATA/config/device-modbus/res/configuration.toml" ]; then
+    mkdir -p "$SNAP_DATA/config/device-modbus/res"
+    cp "$SNAP/config/device-modbus/res/configuration.toml" "$SNAP_DATA/config/device-modbus/res/configuration.toml"
+    # do replacement of the $SNAP, $SNAP_DATA, $SNAP_COMMON environment variables in the config files
+    sed -i -e "s@\$SNAP_COMMON@$SNAP_COMMON@g" \
+        -e "s@\$SNAP_DATA@$SNAP_DATA_CURRENT@g" \
+        -e "s@\$SNAP@$SNAP_CURRENT@g" \
+        "$SNAP_DATA/config/device-modbus/res/configuration.toml"
+fi
+
+# disable device-modbus initially because it specific requires configuration 
+# with a device profile that will be specific to each installation
+snapctl stop --disable "$SNAP_NAME.device-modbus"

--- a/snap/hooks/pre-refresh
+++ b/snap/hooks/pre-refresh
@@ -1,0 +1,6 @@
+#!/bin/bash -e
+
+# save this revision for when we run again in the post-refresh
+snapctl set lastrev="$SNAP_REVISION"
+
+snapctl set release="edinburgh"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,91 @@
+name: edgex-device-modbus
+base: core18
+version: "replace-me"
+license: Apache-2.0
+version-script: |
+  echo $(cat VERSION)-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
+summary: Connect data Modbus to EdgeX using device-modbus reference Device Service
+title: EdgeX MQTT Device Service
+description: |
+  The official reference EdgeX device-modbus Device Service built using the 
+  device-sdk-go to interact with Modbus devices. 
+  Initially the daemon in the snap is disabled - a device profile must be
+  provisioned externally with core-metadata or provided to device-modbus inside
+  "$SNAP_DATA/config/device-modbus/res" before starting.
+
+# TODO: add armhf when the project supports this
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+grade: stable
+confinement: strict
+
+# edinburgh release is epoch 1
+epoch: 1
+
+apps:
+  device-modbus:
+    adapter: none
+    command: bin/device-modbus -confdir $SNAP_DATA/config/device-modbus -profile res --registry
+    daemon: simple
+    plugs: [network, network-bind]
+
+parts:
+  go:
+    plugin: nil
+    build-packages: [curl]
+    source: snap/local
+    override-build: |
+      # use dpkg architecture to figure out our target arch
+      # note - we specifically don't use arch
+      case "$(dpkg --print-architecture)" in
+        amd64)
+          FILE_NAME=go1.11.9.linux-amd64.tar.gz
+          FILE_HASH=e88aa3e39104e3ba6a95a4e05629348b4a1ec82791fb3c941a493ca349730608
+          ;;
+        arm64)
+          FILE_NAME=go1.11.9.linux-arm64.tar.gz
+          FILE_HASH=892ab6c2510c4caa5905b3b1b6a1d4c6f04e384841fec50881ca2be7e8accf05
+          ;;
+        armhf)
+          FILE_NAME=go1.11.9.linux-armv6l.tar.gz
+          FILE_HASH=f0d7b039cae61efdc346669f3459460e3dc03b6c6de528ca107fc53970cba0d1
+          ;;
+        i386)
+          FILE_NAME=go1.11.9.linux-386.tar.gz
+          FILE_HASH=0fa4001fcf1ef0644e261bf6dde02fc9f10ae4df6d74fda61fc4d3c3cbef1d79
+          ;;
+      esac
+      # download the archive, failing on ssl cert problems
+      curl https://dl.google.com/go/$FILE_NAME -O
+      echo "$FILE_HASH $FILE_NAME" > sha256
+      sha256sum -c sha256 | grep OK
+      tar -C $SNAPCRAFT_STAGE -xf go*.tar.gz --strip-components=1
+    prime:
+      - "-*"
+
+  device-modbus:
+    source: .
+    plugin: make
+    build-packages: [git]
+    after: [go]
+    override-build: |
+      cd $SNAPCRAFT_PART_SRC
+      make build
+
+      install -DT "./cmd/device-modbus" "$SNAPCRAFT_PART_INSTALL/bin/device-modbus"
+
+      # FIXME: settings can't be overridden from the cmd-line!
+      # Override 'LogFile' and 'LoggingRemoteURL'
+      install -d "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/"
+
+      cat "./cmd/res/configuration.toml" | \
+        sed -e s:\"./device-modbus.log\":\'\$SNAP_COMMON/device-modbus.log\': \
+          -e s:'ProfilesDir = \"./res\"':'ProfilesDir = \"\$SNAP_DATA/config/device-modbus/res\"': > \
+        "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/configuration.toml"
+
+      install -DT "./cmd/Attribution.txt" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/Attribution.txt"
+      install -DT "./LICENSE" \
+         "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/LICENSE"


### PR DESCRIPTION
Fixes #46

The CI jobs for the snap have been created in https://github.com/edgexfoundry/ci-management/pull/371, so this PR is ready to be reviewed.

To test this snap, on a linux machine (can be a virtual machine):
1. Install snapcraft and multipass with `snap install snapcraft --classic` and `snap install multipass --classic --beta`
2. Checkout this branch using git
3. Build the snap by going to the root directory of this project and running `snapcraft`.
4. The build should produce a .snap file named `edgex-device-modbus*.snap`, install this snap with `snap install --dangerous edgex-device-modbus*.snap`

Assuming all of the above works, the snap is installed and the things to check are:

- [ ] the daemon in the snap is initially disabled (because we don't ship a device profile to use with the service)
- [ ] there is a configuration file for the daemon located in `/var/snap/edgex-device-modbus/current/config/device-modbus/res/configuration.toml`
- [ ] the configuration.toml file doesn't contain any references to the revision, i.e. all paths under `/var/snap/edgex-device-modbus/` start with `current` as in `/var/snap/edgex-device-modbus/current/...` and **not** `/var/snap/edgex-device-modbus/x1/...`

Additionally, if you have access to a system with modbus devices available to test, create a device profile and copy it to `/var/snap/edgex-device-modbus/current/config/device-modbus/res/device.modbus.yaml`, and start the service with `snap start --enable edgex-device-modbus`, and check that the device service runs and collects data correctly, etc. You can see logs from the daemon with `snap logs -f -n=all edgex-device-modbus` or `journalctl -ef -u snap.edgex-device-modbus.*`