### PR TITLE
Load version number from VERSION file

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -13,11 +13,10 @@ import (
 )
 
 const (
-	version     string = device_modbus.Version
 	serviceName string = "edgex-device-modbus"
 )
 
 func main() {
 	sd := driver.NewProtocolDriver()
-	startup.Bootstrap(serviceName, version, sd)
+	startup.Bootstrap(serviceName, device_modbus.Version, sd)
 }

--- a/version.go
+++ b/version.go
@@ -7,4 +7,4 @@
 package device_modbus
 
 // Global version for device-sdk-go
-const Version string = "0.7.0"
+var Version string = "to be replaced by makefile"


### PR DESCRIPTION
The Version field will override when running the build command(make build)
`go build -ldflags "-X github.com/edgexfoundry/device-modbus-go.Version=$(VERSION)"`

Fix #21 