### PR TITLE
Remove --registry from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,4 @@ EXPOSE $APP_PORT
 
 COPY --from=builder /go/src/github.com/edgexfoundry/device-modbus-go/cmd /
 
-ENTRYPOINT ["/device-modbus","--registry","--profile=docker","--confdir=/res"]
+ENTRYPOINT ["/device-modbus","--profile=docker","--confdir=/res"]

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/edgexfoundry/device-modbus-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20190525113747-79c5093a958b
-	github.com/edgexfoundry/go-mod-core-contracts v0.0.1
+	github.com/edgexfoundry/device-sdk-go v0.0.0-20190529004611-4ec3ceb83e9b
+	github.com/edgexfoundry/go-mod-core-contracts v0.1.0
 	github.com/go-stack/stack v1.8.0 // indirect
 	github.com/goburrow/modbus v0.1.0
 	github.com/goburrow/serial v0.1.0


### PR DESCRIPTION
Should not include --registry in the command line. It is consistent with the C Device Services.

Fix #51 