### PR TITLE
Adds support for the Modbus WriteSingleRegister command

### DIFF
--- a/internal/driver/modbusclient.go
+++ b/internal/driver/modbusclient.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"os"
 	"strings"
+	"encoding/binary"
 
 	MODBUS "github.com/goburrow/modbus"
 )
@@ -102,7 +103,11 @@ func (c *ModbusClient) SetValue(commandInfo interface{}, value []byte) error {
 		result, err = c.client.WriteMultipleRegisters(uint16(modbusCommandInfo.StartingAddress), modbusCommandInfo.Length, value)
 
 	case HOLDING_REGISTERS:
-		result, err = c.client.WriteMultipleRegisters(uint16(modbusCommandInfo.StartingAddress), modbusCommandInfo.Length, value)
+		if modbusCommandInfo.Length == 1 {
+		  result, err = c.client.WriteSingleRegister(uint16(modbusCommandInfo.StartingAddress), binary.BigEndian.Uint16(value))
+		} else {		
+		  result, err = c.client.WriteMultipleRegisters(uint16(modbusCommandInfo.StartingAddress), modbusCommandInfo.Length, value)
+		}
 	default:
 	}
 


### PR DESCRIPTION
Signed-off-by: Dave Rensberger <davidr@beechwoods.com>

The device-modbus-go code currently assumes that you don’t need to use the “WriteSingleRegister” method in the modbus library (doing a “WriteMultipleRegister” with a parameter of 1 register is NOT the same as WriteSingleRegister at the serial protocol level. For one of my devices, I found this to not hold true. I think this can be fixed without introducing any backward-compatibility issues by making these changes.

Fix #60 