### PR TITLE
Specify consul addr in registry arg in snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,7 +27,9 @@ epoch: 1
 apps:
   device-modbus:
     adapter: none
-    command: bin/device-modbus -confdir $SNAP_DATA/config/device-modbus -profile res --registry
+    command: bin/device-modbus -confdir $SNAP_DATA/config/device-modbus -profile res --registry $CONSUL_ADDR
+    environment:
+      CONSUL_ADDR: "consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
As per https://github.com/edgexfoundry/device-sdk-go/pull/274, the
registry arg for device services now needs a value, so use the default
value of consul from the edgexfoundry snap.

Fixes #65 