### PR TITLE
Add rawType attribute to define binary data for casting the data type from integer to float

### DIFF
--- a/internal/driver/constant.go
+++ b/internal/driver/constant.go
@@ -1,6 +1,6 @@
 // -*- Mode: Go; indent-tabs-mode: t -*-
 //
-// Copyright (C) 2018 IOTech Ltd
+// Copyright (C) 2018-2019 IOTech Ltd
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -26,6 +26,11 @@ const (
 	COILS             = "COILS"
 	INPUT_REGISTERS   = "INPUT_REGISTERS"
 	HOLDING_REGISTERS = "HOLDING_REGISTERS"
+
+	PRIMARY_TABLE    = "primaryTable"
+	STARTING_ADDRESS = "startingAddress"
+	// RAW_TYPE define binary data type which read from Modbus device
+	RAW_TYPE = "rawType"
 )
 
 var PrimaryTableBitCountMap = map[string]uint16{

--- a/internal/driver/deviceclient_test.go
+++ b/internal/driver/deviceclient_test.go
@@ -17,7 +17,7 @@ import (
 
 func init() {
 	driver = new(Driver)
-	driver.Logger = logger.NewClient("test", false, "", "DEBUG")
+	driver.Logger = logger.NewClient("test", false, "./device-Modbus.log", "DEBUG")
 }
 
 // Test byte, word swap
@@ -45,7 +45,7 @@ func TestWordSwap32BitDataBytes(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_INT16(t *testing.T) {
+func TestTransformDataBytesToResult_INT16(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Int16,
@@ -54,11 +54,14 @@ func TestTransformDateBytesToResult_INT16(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{255, 231} // => big-endian [231,255] => -25
 	expected := int16(-25)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
@@ -69,7 +72,7 @@ func TestTransformDateBytesToResult_INT16(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_INT32(t *testing.T) {
+func TestTransformDataBytesToResult_INT32(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Int32,
@@ -78,11 +81,14 @@ func TestTransformDateBytesToResult_INT32(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{0, 0, 1, 11} // big-endian [11,1,0,0] => 11+2^8=267
 	expected := int32(267)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
 	}
@@ -92,7 +98,7 @@ func TestTransformDateBytesToResult_INT32(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_INT64(t *testing.T) {
+func TestTransformDataBytesToResult_INT64(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Int64,
@@ -101,11 +107,14 @@ func TestTransformDateBytesToResult_INT64(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{0, 1, 0, 0, 0, 2, 1, 1} // big-endian [1,1,2,0,0,0,1,0] => 1+2^8+2^17+2^48=281474976841985
 	expected := int64(281474976841985)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
 	}
@@ -115,7 +124,7 @@ func TestTransformDateBytesToResult_INT64(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_UINT16(t *testing.T) {
+func TestTransformDataBytesToResult_UINT16(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Uint16,
@@ -124,11 +133,14 @@ func TestTransformDateBytesToResult_UINT16(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{0, 11} // => big-endian [11,0] => 11
 	expected := uint16(11)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
@@ -139,7 +151,7 @@ func TestTransformDateBytesToResult_UINT16(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_UINT32(t *testing.T) {
+func TestTransformDataBytesToResult_UINT32(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Uint32,
@@ -148,11 +160,14 @@ func TestTransformDateBytesToResult_UINT32(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{0, 0, 1, 11} // big-endian [11,1,0,0] => 11+2^8=267
 	expected := uint32(267)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
 	}
@@ -162,7 +177,7 @@ func TestTransformDateBytesToResult_UINT32(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_UINT64(t *testing.T) {
+func TestTransformDataBytesToResult_UINT64(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Uint64,
@@ -171,12 +186,15 @@ func TestTransformDateBytesToResult_UINT64(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{0, 1, 0, 0, 0, 2, 1, 1} // big-endian [1,1,2,0,0,0,1,0] => 1+2^8+2^17+2^48=281474976841985
 
 	expected := uint64(281474976841985)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
 	}
@@ -186,7 +204,7 @@ func TestTransformDateBytesToResult_UINT64(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_FLOAT32(t *testing.T) {
+func TestTransformDataBytesToResult_FLOAT32(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Float32,
@@ -195,11 +213,14 @@ func TestTransformDateBytesToResult_FLOAT32(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{63, 143, 92, 41} // big-endian [41,92,143,63] => 1.12
 	expected := float32(1.12)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
 	}
@@ -209,7 +230,7 @@ func TestTransformDateBytesToResult_FLOAT32(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_FLOAT64(t *testing.T) {
+func TestTransformDataBytesToResult_FLOAT64(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Float64,
@@ -218,11 +239,14 @@ func TestTransformDateBytesToResult_FLOAT64(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{63, 241, 235, 133, 30, 184, 81, 236} // => 1.12
 	expected := float64(1.12)
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
 	}
@@ -232,7 +256,7 @@ func TestTransformDateBytesToResult_FLOAT64(t *testing.T) {
 	}
 }
 
-func TestTransformDateBytesToResult_BOOL(t *testing.T) {
+func TestTransformDataBytesToResult_BOOL(t *testing.T) {
 	req := sdkModel.CommandRequest{
 		DeviceResourceName: "light",
 		Type:               sdkModel.Bool,
@@ -241,17 +265,142 @@ func TestTransformDateBytesToResult_BOOL(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	dataBytes := []byte{1} // => 00000001
 	expected := true
 
-	commandValue, err := TransformDateBytesToResult(&req, dataBytes, commandInfo)
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
 	if err != nil {
 		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
 	}
 	result, err := commandValue.BoolValue()
 	if err != nil || expected != result {
 		t.Fatalf("Unexpected result. Error: %v", err)
+	}
+}
+
+func TestTransformDataBytesToResult_RawType_INT16_ValueType_FLOAT32(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float32,
+		Attributes: map[string]string{
+			PRIMARY_TABLE:    INPUT_REGISTERS,
+			STARTING_ADDRESS: "10",
+			RAW_TYPE:         INT16,
+		},
+	}
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	dataBytes := []byte{255, 231} // => big-endian [231,255] => -25
+	expected := float32(-25)
+
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
+	}
+	result, err := commandValue.Float32Value()
+	if err != nil {
+		t.Fatalf("Unexpected result. Error: %v", err)
+	} else if expected != result {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, result)
+	}
+}
+
+func TestTransformDataBytesToResult_RawType_UINT16_ValueType_FLOAT32(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float32,
+		Attributes: map[string]string{
+			PRIMARY_TABLE:    INPUT_REGISTERS,
+			STARTING_ADDRESS: "10",
+			RAW_TYPE:         UINT16,
+		},
+	}
+
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	dataBytes := []byte{0, 11} // => big-endian [11,0] => 11
+	expected := float32(11)
+
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
+	}
+	result, err := commandValue.Float32Value()
+	if err != nil {
+		t.Fatalf("Unexpected result. Error: %v", err)
+	} else if expected != result {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, result)
+	}
+}
+
+func TestTransformDataBytesToResult_RawType_INT16_ValueType_FLOAT64(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float64,
+		Attributes: map[string]string{
+			PRIMARY_TABLE:    INPUT_REGISTERS,
+			STARTING_ADDRESS: "10",
+			RAW_TYPE:         INT16,
+		},
+	}
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	dataBytes := []byte{255, 231} // => big-endian [231,255] => -25
+	expected := float64(-25)
+
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
+	}
+	result, err := commandValue.Float64Value()
+	if err != nil {
+		t.Fatalf("Unexpected result. Error: %v", err)
+	} else if expected != result {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, result)
+	}
+}
+
+func TestTransformDataBytesToResult_RawType_UINT16_ValueType_FLOAT64(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float64,
+		Attributes: map[string]string{
+			PRIMARY_TABLE:    INPUT_REGISTERS,
+			STARTING_ADDRESS: "10",
+			RAW_TYPE:         UINT16,
+		},
+	}
+
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	dataBytes := []byte{0, 11} // => big-endian [11,0] => 11
+	expected := float64(11)
+
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform data bytes to result. Error: %v", err)
+	}
+	result, err := commandValue.Float64Value()
+	if err != nil {
+		t.Fatalf("Unexpected result. Error: %v", err)
+	} else if expected != result {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, result)
 	}
 }
 
@@ -264,7 +413,10 @@ func TestTransformCommandValueToDataBytes_INT16(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewInt16Value(req.DeviceResourceName, resTime, -25)
 	expected := []byte{255, 231}
@@ -285,7 +437,10 @@ func TestTransformCommandValueToDataBytes_INT32(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewInt32Value(req.DeviceResourceName, resTime, 267)
 	expected := []byte{0, 0, 1, 11}
@@ -306,7 +461,10 @@ func TestTransformCommandValueToDataBytes_INT64(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewInt64Value(req.DeviceResourceName, resTime, 281474976841985)
 	expected := []byte{0, 1, 0, 0, 0, 2, 1, 1}
@@ -326,7 +484,10 @@ func TestTransformCommandValueToDataBytes_UINT16(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewUint16Value(req.DeviceResourceName, resTime, 11)
 	expected := []byte{0, 11}
@@ -347,7 +508,10 @@ func TestTransformCommandValueToDataBytes_UINT32(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewUint32Value(req.DeviceResourceName, resTime, 267)
 	expected := []byte{0, 0, 1, 11}
@@ -368,7 +532,10 @@ func TestTransformCommandValueToDataBytes_UINT64(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewUint64Value(req.DeviceResourceName, resTime, 281474976841985)
 	expected := []byte{0, 1, 0, 0, 0, 2, 1, 1}
@@ -389,7 +556,10 @@ func TestTransformCommandValueToDataBytes_FLOAT32(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewFloat32Value(req.DeviceResourceName, resTime, 1.12)
 	expected := []byte{63, 143, 92, 41}
@@ -410,7 +580,10 @@ func TestTransformCommandValueToDataBytes_FLOAT64(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewFloat64Value(req.DeviceResourceName, resTime, 1.12)
 	expected := []byte{63, 241, 235, 133, 30, 184, 81, 236}
@@ -431,7 +604,10 @@ func TestTransformCommandValueToDataBytes_BOOL(t *testing.T) {
 			"startingAddress": "10",
 		},
 	}
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
 	resTime := time.Now().UnixNano()
 	val, _ := sdkModel.NewBoolValue(req.DeviceResourceName, resTime, true)
 	expected := []byte{1}
@@ -440,5 +616,113 @@ func TestTransformCommandValueToDataBytes_BOOL(t *testing.T) {
 
 	if err != nil || !bytes.Equal(dataBytes, expected) {
 		t.Fatalf("Fail to tramsform command value to data bytes. Error: %v", err)
+	}
+}
+
+func TestTransformCommandValueToDataBytes_ValueType_FLOAT32_RawType_INT16(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float32,
+		Attributes: map[string]string{
+			"primaryTable":    HOLDING_REGISTERS,
+			"startingAddress": "10",
+			RAW_TYPE:          INT16,
+		},
+	}
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	resTime := time.Now().UnixNano()
+	val, _ := sdkModel.NewFloat32Value(req.DeviceResourceName, resTime, -52.0)
+	expected := []byte{255, 204}
+
+	dataBytes, err := TransformCommandValueToDataBytes(commandInfo, val)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform command value to data bytes. Error: %v", err)
+	} else if !bytes.Equal(dataBytes, expected) {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, dataBytes)
+	}
+}
+
+func TestTransformCommandValueToDataBytes_ValueType_FLOAT32_RawType_UINT16(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float32,
+		Attributes: map[string]string{
+			"primaryTable":    HOLDING_REGISTERS,
+			"startingAddress": "10",
+			RAW_TYPE:          UINT16,
+		},
+	}
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	resTime := time.Now().UnixNano()
+	val, _ := sdkModel.NewFloat32Value(req.DeviceResourceName, resTime, 112.1)
+	expected := []byte{0, 112}
+
+	dataBytes, err := TransformCommandValueToDataBytes(commandInfo, val)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform command value to data bytes. Error: %v", err)
+	} else if !bytes.Equal(dataBytes, expected) {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, dataBytes)
+	}
+}
+
+func TestTransformCommandValueToDataBytes_ValueType_FLOAT64_RawType_INT16(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float64,
+		Attributes: map[string]string{
+			"primaryTable":    HOLDING_REGISTERS,
+			"startingAddress": "10",
+			RAW_TYPE:          INT16,
+		},
+	}
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	resTime := time.Now().UnixNano()
+	val, _ := sdkModel.NewFloat64Value(req.DeviceResourceName, resTime, -52.0)
+	expected := []byte{255, 204}
+
+	dataBytes, err := TransformCommandValueToDataBytes(commandInfo, val)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform command value to data bytes. Error: %v", err)
+	} else if !bytes.Equal(dataBytes, expected) {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, dataBytes)
+	}
+}
+
+func TestTransformCommandValueToDataBytes_ValueType_FLOAT64_RawType_UINT16(t *testing.T) {
+	req := sdkModel.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               sdkModel.Float64,
+		Attributes: map[string]string{
+			"primaryTable":    HOLDING_REGISTERS,
+			"startingAddress": "10",
+			RAW_TYPE:          UINT16,
+		},
+	}
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		t.Fatalf("Fail to createcommandInfo. Error: %v", err)
+	}
+	resTime := time.Now().UnixNano()
+	val, _ := sdkModel.NewFloat64Value(req.DeviceResourceName, resTime, 112.1)
+	expected := []byte{0, 112}
+
+	dataBytes, err := TransformCommandValueToDataBytes(commandInfo, val)
+
+	if err != nil {
+		t.Fatalf("Fail to tramsform command value to data bytes. Error: %v", err)
+	} else if !bytes.Equal(dataBytes, expected) {
+		t.Fatalf("Unexpected result. expected result %v should equal to %v", expected, dataBytes)
 	}
 }

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -128,7 +128,10 @@ func (d *Driver) handleReadCommandRequest(deviceClient DeviceClient, req sdkMode
 	var result = &sdkModel.CommandValue{}
 	var err error
 
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		return nil, err
+	}
 
 	response, err = deviceClient.GetValue(commandInfo)
 	if err != nil {
@@ -136,7 +139,7 @@ func (d *Driver) handleReadCommandRequest(deviceClient DeviceClient, req sdkMode
 	}
 
 	//stringResult := TransformDateBytesToString(response, commandInfo)
-	result, err = TransformDateBytesToResult(&req, response, commandInfo)
+	result, err = TransformDataBytesToResult(&req, response, commandInfo)
 
 	if err != nil {
 		return result, err
@@ -197,7 +200,10 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 func (d *Driver) handleWriteCommandRequest(deviceClient DeviceClient, req sdkModel.CommandRequest, param *sdkModel.CommandValue) error {
 	var err error
 
-	commandInfo := createCommandInfo(&req)
+	commandInfo, err := createCommandInfo(&req)
+	if err != nil {
+		return err
+	}
 
 	dataBytes, err := TransformCommandValueToDataBytes(commandInfo, param)
 	if err != nil {

--- a/internal/driver/driver_test.go
+++ b/internal/driver/driver_test.go
@@ -15,11 +15,11 @@ import (
 
 func init() {
 	driver = new(Driver)
-	driver.Logger = logger.NewClient("test", false, "", "DEBUG")
+	driver.Logger = logger.NewClient("test", false, "./device-Modbus.log", "DEBUG")
 }
 
 func TestLockAddressWithAddressCountLimit(t *testing.T) {
-	address := "/dev/USB0tty,19200,8,1,0"
+	address := "/dev/USB0tty"
 	driver.addressMap = make(map[string]chan bool)
 	driver.workingAddressCount = make(map[string]int)
 	driver.workingAddressCount[address] = concurrentCommandLimit
@@ -32,7 +32,7 @@ func TestLockAddressWithAddressCountLimit(t *testing.T) {
 }
 
 func TestLockAddressWithAddressCountUnderLimit(t *testing.T) {
-	address := "/dev/USB0tty,19200,8,1,0"
+	address := "/dev/USB0tty"
 	driver.addressMap = make(map[string]chan bool)
 	driver.workingAddressCount = make(map[string]int)
 	driver.workingAddressCount[address] = concurrentCommandLimit - 1


### PR DESCRIPTION
Fix #78 

Add rawType attribute to define binary data type
* Read command can use rawType to parse the binary data and use valueType to cast the integer to float. 
* Write command can use rawType to cast the float to integer.

This feature only support :
* integer 16 bits to float.
* float to integer 16 bits