### PR TITLE
Set up the default ProfilesDir path to ./res

### DIFF
--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -52,5 +52,5 @@ LogLevel = "INFO"
   MaxCmdValueLen = 256
   RemoveCmd = ""
   RemoveCmdArgs = ""
-  ProfilesDir = ""
+  ProfilesDir = "./res"
   

--- a/cmd/res/docker/configuration.toml
+++ b/cmd/res/docker/configuration.toml
@@ -52,4 +52,4 @@ LogLevel = "INFO"
   MaxCmdValueLen = 256
   RemoveCmd = ""
   RemoveCmdArgs = ""
-  ProfilesDir = ""
+  ProfilesDir = "./res"


### PR DESCRIPTION
Fix #84 
Set up the default ProfilesDir path as ./res to following files
* cmd/res/configuration.toml
* cmd/res/docker/configuration.toml