### PR TITLE
Update SDK version to v1.1.0 for fuji branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/edgexfoundry/device-modbus-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go v0.0.0-20191023171807-49a95f741ef7
+	github.com/edgexfoundry/device-sdk-go v1.1.0
 	github.com/edgexfoundry/go-mod-core-contracts v0.1.31
 	github.com/goburrow/modbus v0.1.0
 	github.com/goburrow/serial v0.1.0


### PR DESCRIPTION
Fix #95 
Update device-sdk-go to v1.1.0