### PR TITLE
Fuji: Enable the go vet line in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ cmd/device-modbus:
 
 test:
 	$(GO) test ./... -coverprofile=coverage.out
-#	$(GO) vet ./...
+	$(GO) vet ./...
 	gofmt -l .
 	[ "`gofmt -l .`" = "" ]
 	./bin/test-attribution-txt.sh


### PR DESCRIPTION
Fix #99 