### PR TITLE
Fuji: Add license/copyright labels to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,4 +24,7 @@ EXPOSE $APP_PORT
 
 COPY --from=builder /go/src/github.com/edgexfoundry/device-modbus-go/cmd /
 
+LABEL license='SPDX-License-Identifier: Apache-2.0' \
+      copyright='Copyright (c) 2019: IoTech Ltd'
+
 ENTRYPOINT ["/device-modbus","--profile=docker","--confdir=/res","--registry=consul://edgex-core-consul:8500"]


### PR DESCRIPTION
Fuji: Add license/copyright labels to the docker container.
Fix #113 