### PR TITLE
Fuji update snap to 1.1.1

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,9 +27,11 @@ epoch: 1
 apps:
   device-modbus:
     adapter: none
-    command: bin/device-modbus -confdir $SNAP_DATA/config/device-modbus -profile res --registry $CONSUL_ADDR
+    command: bin/device-modbus $CONF_ARG $PROFILE_ARG $REGISTRY_ARG
     environment:
-      CONSUL_ADDR: "consul://localhost:8500"
+      CONF_ARG: "--confdir=$SNAP_DATA/config/device-modbus"
+      PROFILE_ARG: "--profile=res"
+      REGISTRY_ARG: "--registry=consul://localhost:8500"
     daemon: simple
     plugs: [network, network-bind]
 


### PR DESCRIPTION
Update the snap to the 1.1.1.

This has been tested against the latest stable version of the edgexfoundry snap (version: 1.1.0-20200213+5c8c3243, revision: 2049) on an Ubuntu Desktop system running 18.04 LTS.