### PR TITLE
Fix doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Overview
 Modbus Micro Service - device service for connecting Modbus devices to EdgeX.
 ## Usage
-Users can refer to [the document](https://docs.edgexfoundry.org/Ch-ExamplesAddingModbusDevice.html) to learn how to use this device service.
+Users can refer to [the document](https://docs.edgexfoundry.org/1.2/examples/Ch-ExamplesAddingModbusDevice) to learn how to use this device service.
 
 ## Community
 - Chat: https://edgexfoundry.slack.com


### PR DESCRIPTION
Change the link to https://docs.edgexfoundry.org/1.2/examples/Ch-ExamplesAddingModbusDevice
Fix #131 