### PR TITLE
Use current mavenSettings from device-modbus-go

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@
 
 edgeXBuildDocker (
     project: 'edgex-modbus-simulator',
-    mavenSettings: 'edgex-modbus-simulator-settings',
+    mavenSettings: 'device-modbus-go-settings',
     dockerImageName: 'edgex-modbus-simulator',
     dockerNamespace: 'edgex-devops',
     dockerNexusRepo: 'snapshots',


### PR DESCRIPTION
Use current mavenSettings from device-modbus-go.

The maven setting can be found in the Jenkins page
https://jenkins.edgexfoundry.org/view/EdgeX%20Foundry%20Project/job/edgexfoundry/job/device-modbus-go/job/master/4/consoleFull

Fix #135