### PR TITLE
snap: add env override for ProfilesDir

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -30,6 +30,7 @@ apps:
     command: bin/device-modbus -confdir $SNAP_DATA/config/device-modbus -profile res --registry $CONSUL_ADDR
     environment:
       CONSUL_ADDR: "consul://localhost:8500"
+      DEVICE_PROFILESDIR: $SNAP_DATA/config/device-modbus/res
     daemon: simple
     plugs: [network, network-bind]
 
@@ -77,15 +78,7 @@ parts:
       make build
 
       install -DT "./cmd/device-modbus" "$SNAPCRAFT_PART_INSTALL/bin/device-modbus"
-
-      # FIXME: settings can't be overridden from the cmd-line!
-      # Override 'LogFile' and 'LoggingRemoteURL'
-      install -d "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/"
-
-      cat "./cmd/res/configuration.toml" | \
-        sed -e s:\"./device-modbus.log\":\'\$SNAP_COMMON/device-modbus.log\': \
-          -e s:'ProfilesDir = \"./res\"':'ProfilesDir = \"\$SNAP_DATA/config/device-modbus/res\"': > \
-        "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/configuration.toml"
+      install -DT "./cmd/res/configuration.toml" "$SNAPCRAFT_PART_INSTALL/config/device-modbus/res/configuration.toml"
 
       install -DT "./Attribution.txt" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/Attribution.txt"


### PR DESCRIPTION
This change removes the build-time edit of the `configuration.toml` file and instead uses an
environment variable config override to update **Device.ProfilesDir**.

This resolves issue #152.

To test, install the main edgex snap, install the snap built from this PR, start a command to watch log output, and then start the service:

```
$ sudo snap install edgexfoundry
$ sudo snap install edgex-device-modbus_*.snap --dangerous
$ sudo snap logs edgex-device-modbus.device-modbus -f | grep "Environment override"
```
**Note** -- the `--dangerous` flag is used to install an unsigned snap (i.e. a snap that's been built locally).

In another terminal run:

```$ sudo snap start edgex-device-modbus.device-modbus```

You should see the following log message output:

> 2020-06-04T14:46:19Z edgex-device-modbus.device-modbus [4899]: level=INFO ts=2020-06-04T14:46:19.436460404Z app=edgex-device-modbus source=environment.go:327 msg="Environment override of 'Device.ProfilesDir' by environment variable: DEVICE_PROFILESDIR=/var/snap/edgex-device-modbus/x1/config/device-modbus/res"
