### PR TITLE
fix: Lock Modbus TCP address with IP and Port

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -76,6 +76,17 @@ func (d *Driver) unlockAddress(address string) {
 	<-lock
 }
 
+// lockableAddress return the lockable address according to the protocol
+func (d *Driver) lockableAddress(info *ConnectionInfo) string {
+	var address string
+	if info.Protocol == ProtocolTCP {
+		address = fmt.Sprintf("%s:%d", info.Address, info.Port)
+	} else {
+		address = info.Address
+	}
+	return address
+}
+
 func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]models.ProtocolProperties, reqs []sdkModel.CommandRequest) (responses []*sdkModel.CommandValue, err error) {
 	connectionInfo, err := createConnectionInfo(protocols)
 	if err != nil {
@@ -83,11 +94,11 @@ func (d *Driver) HandleReadCommands(deviceName string, protocols map[string]mode
 		return responses, err
 	}
 
-	err = d.lockAddress(connectionInfo.Address)
+	err = d.lockAddress(d.lockableAddress(connectionInfo))
 	if err != nil {
 		return responses, err
 	}
-	defer d.unlockAddress(connectionInfo.Address)
+	defer d.unlockAddress(d.lockableAddress(connectionInfo))
 
 	responses = make([]*sdkModel.CommandValue, len(reqs))
 	var deviceClient DeviceClient
@@ -161,11 +172,11 @@ func (d *Driver) HandleWriteCommands(deviceName string, protocols map[string]mod
 		return err
 	}
 
-	err = d.lockAddress(connectionInfo.Address)
+	err = d.lockAddress(d.lockableAddress(connectionInfo))
 	if err != nil {
 		return err
 	}
-	defer d.unlockAddress(connectionInfo.Address)
+	defer d.unlockAddress(d.lockableAddress(connectionInfo))
 
 	var deviceClient DeviceClient
 


### PR DESCRIPTION
fix #164

Signed-off-by: weichou <weichou1229@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
Modbus DS use IP to lock address for modbus-tcp.

Issue Number: #164 


## What is the new behavior?
Modbus DS combines IP and Port as lockable address for modbus-tcp

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information