### PR TITLE
feat: Enhance Modbus simulator to measure reading amount

### DIFF
--- a/simulator/README.md
+++ b/simulator/README.md
@@ -21,3 +21,7 @@ docker build -t modbus-simulator .
         -e SIMULATOR_NUMBER=1000 -e STARTING_PORT=10000 modbus-simulator
     ```
     To handle a lot of ports, docker recommends user using the host network, see https://docs.docker.com/network/host/.
+    
+    In scalability test mode, the simulator will count the Modbus command amount as the reading amount and provide APIs for edgex-taf to measure the event amount: 
+    * Query reading amount: http://localhost:1503/reading/count
+    * Reset reading amount: http://localhost:1503/reading/reset

--- a/simulator/main.go
+++ b/simulator/main.go
@@ -10,6 +10,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
+	"net/http"
 	"os"
 	"os/signal"
 	"strconv"
@@ -24,6 +25,7 @@ const (
 	protocolTCP            = "TCP"
 	protocolRTU            = "RTU"
 	defaultDevicePort      = 1502
+	simulatorServicePort   = 1503
 	host                   = "0.0.0.0"
 	startingPortEnvName    = "STARTING_PORT"
 	simulatorNumberEnvName = "SIMULATOR_NUMBER"
@@ -33,6 +35,8 @@ const (
 
 var devices []*mbserver.Server
 var mutex = &sync.Mutex{}
+var mu sync.Mutex
+var readingAmount uint
 
 func main() {
 	c := make(chan os.Signal, 1)
@@ -56,6 +60,17 @@ func main() {
 			log.Printf("Close %d mock devices. \n", len(devices))
 		}()
 
+		log.Println("Start a HTTP server to provide the reading count.")
+		http.HandleFunc("/reading/count/reset", func(w http.ResponseWriter, r *http.Request) {
+			readingAmount = 0
+		})
+
+		http.HandleFunc("/reading/count", func(w http.ResponseWriter, r *http.Request) {
+			fmt.Fprintf(w, "%d", readingAmount)
+		})
+
+		log.Fatal(http.ListenAndServe(fmt.Sprintf(":%d", simulatorServicePort), nil))
+
 	} else {
 		if *protocol == protocolTCP {
 			err := createTCPDevice(defaultDevicePort)
@@ -77,6 +92,7 @@ func main() {
 
 func createTCPDevice(port int) error {
 	device := mbserver.NewServer()
+	overrideRegisterFunctionHandler(device)
 	url := fmt.Sprintf("%s:%d", host, port)
 	if err := device.ListenTCP(url); err != nil {
 		return fmt.Errorf("the Modbus TCP device cann't listen on %s, %v", url, err)
@@ -88,6 +104,7 @@ func createTCPDevice(port int) error {
 
 func createRTUDevice() error {
 	device := mbserver.NewServer()
+	overrideRegisterFunctionHandler(device)
 	config := &serial.Config{
 		Address:  "/tmp/master",
 		BaudRate: 19200,
@@ -142,4 +159,38 @@ func createScalabilityTestSimulators() error {
 		return fmt.Errorf("fail to scale %d devices, %v \n", simulatorNumber, err)
 	}
 	return nil
+}
+
+func increaseReadingAmount() {
+	mu.Lock()
+	readingAmount++
+	mu.Unlock()
+}
+
+// Override the modbus function https://github.com/tbrandon/mbserver/blob/master/functions.go
+func overrideRegisterFunctionHandler(server *mbserver.Server) {
+	// coils
+	server.RegisterFunctionHandler(1,
+		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+			increaseReadingAmount()
+			return mbserver.ReadCoils(s, frame)
+		})
+	// discrete inputs
+	server.RegisterFunctionHandler(2,
+		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+			increaseReadingAmount()
+			return mbserver.ReadDiscreteInputs(s, frame)
+		})
+	// holding registers
+	server.RegisterFunctionHandler(3,
+		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+			increaseReadingAmount()
+			return mbserver.ReadHoldingRegisters(s, frame)
+		})
+	// input registers
+	server.RegisterFunctionHandler(4,
+		func(s *mbserver.Server, frame mbserver.Framer) ([]byte, *mbserver.Exception) {
+			increaseReadingAmount()
+			return mbserver.ReadInputRegisters(s, frame)
+		})
 }


### PR DESCRIPTION
Fix #190

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

Issue Number: #190


## What is the new behavior?
Modbus simulator counts the Modbus command amount as the reading amount and provides GET reading amount API for the test requirement.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?


## Are there any specific instructions or things that should be known prior to reviewing?

## Other information