### PR TITLE
feat(snap): Add startup configure options and update versioning logic

### DIFF
--- a/snap/README.md
+++ b/snap/README.md
@@ -1,0 +1,34 @@
+# EdgeX Modbus Device Service Snap
+[![snap store badge](https://raw.githubusercontent.com/snapcore/snap-store-badges/master/EN/%5BEN%5D-snap-store-black-uneditable.png)](https://snapcraft.io/edgex-device-modbus)
+
+This folder contains snap packaging for the EdgeX Modbus Device Service Snap
+
+The snap currently supports both `amd64` and `arm64` platforms.
+
+
+## Snap configuration
+
+Device services implement a service dependency check on startup which ensures that all of the runtime dependencies of a particular service are met before the service transitions to active state.
+
+Snapd doesn't support orchestration between services in different snaps. It is therefore possible on a reboot for a device service to come up faster than all of the required services running in the main edgexfoundry snap. If this happens, it's possible that the device service repeatedly fails startup, and if it exceeds the systemd default limits, then it might be left in a failed state. This situation might be more likely on constrained hardware (e.g. RPi).
+
+This snap therefore implements a basic retry loop with a maximum duration and sleep interval. If the dependent services are not available, the service sleeps for the defined interval (default: 1s) and then tries again up to a maximum duration (default: 60s). These values can be overridden with the following commands:
+    
+To change the maximum duration, use the following command:
+
+```bash
+$ sudo snap set edgex-device-modbus startup-duration=60
+```
+
+To change the interval between retries, use the following command:
+
+```bash
+$ sudo snap set edgex-device-modbus startup-interval=1
+```
+
+The service can then be started as follows. The "--enable" option
+ensures that as well as starting the service now, it will be automatically started on boot:
+
+```bash
+$ sudo snap start --enable edgex-device-modbus.device-modbus
+```

--- a/snap/local/runtime-helpers/bin/startup-env-var.sh
+++ b/snap/local/runtime-helpers/bin/startup-env-var.sh
@@ -1,0 +1,15 @@
+#!/bin/sh -e
+
+EDGEX_STARTUP_DURATION=$(snapctl get startup-duration)
+
+if [ -n "$EDGEX_STARTUP_DURATION" ]; then
+  export EDGEX_STARTUP_DURATION
+fi
+
+EDGEX_STARTUP_INTERVAL=$(snapctl get startup-interval)
+
+if [ -n "$EDGEX_STARTUP_INTERVAL" ]; then
+  export EDGEX_STARTUP_INTERVAL
+fi
+
+exec "$@"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -33,6 +33,8 @@ apps:
   device-modbus:
     adapter: none
     command: bin/device-modbus -confdir $SNAP_DATA/config/device-modbus -profile res --registry $CONSUL_ADDR
+    command-chain:
+      - bin/startup-env-var.sh
     environment:
       CONSUL_ADDR: "consul://localhost:8500"
       DEVICE_PROFILESDIR: $SNAP_DATA/config/device-modbus/res
@@ -89,3 +91,6 @@ parts:
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/Attribution.txt"
       install -DT "./LICENSE" \
          "$SNAPCRAFT_PART_INSTALL/usr/share/doc/device-modbus/LICENSE"
+  config-common:
+    plugin: dump
+    source: snap/local/runtime-helpers

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,14 +1,7 @@
 name: edgex-device-modbus
 base: core18
-version: "replace-me"
 license: Apache-2.0
-version-script: |
-  if [ -f VERSION ]; then
-    PROJECT_VERSION=$(cat VERSION)
-  else
-    PROJECT_VERSION=local-dev
-  fi
-    echo $PROJECT_VERSION-$(date +%Y%m%d)+$(git rev-parse --short HEAD)
+adopt-info: version
 summary: Connect data Modbus to EdgeX using device-modbus reference Device Service
 title: EdgeX Modbus Device Service
 description: |
@@ -42,6 +35,17 @@ apps:
     plugs: [network, network-bind]
 
 parts:
+  version:
+    plugin: nil
+    source: snap/local
+    override-pull: |
+      cd $SNAPCRAFT_PROJECT_DIR
+      if [ -f VERSION ]; then
+        PROJECT_VERSION=$(cat VERSION)
+      else
+        PROJECT_VERSION="0.0.0"
+      fi
+      snapcraftctl set-version ${PROJECT_VERSION}
   go:
     plugin: nil
     build-packages: [curl]


### PR DESCRIPTION
1) Add two new configure options:

- To change the default startup duration use:
sudo snap set edgex-device-modbus startup-duration=n

- To change the default startup interval use:
sudo snap set edgex-device-modbus startup-interval=n

2) Update the way version numbers are
generated when building the snap:

- Remove git tag and datestamp from the version number.
    ('1.1.3-dev.5' vs '1.1.3-dev.4-20201021+856f4f8')
- Use 'snapcraftctl set-version' instead of deprecated 'version-script'

Signed-off-by: Siggi Skulason <siggi.skulason@canonical.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->

1) The module go-mod-bootstrap implements a service dependency check on startup which ensures that all of the runtime dependencies of a particular service are met before the service transitions to active state. The logic implements a basic retry loop with a maximum duration and sleep interval. If the dependent services are not available, the service sleeps for the defined interval (default: 1s) and then tries again up to a maximum duration (default: 60s). These values can be overridden via environment variables.

2) The snap version is in the format "1.1.3-dev.4-20201021+856f4f8"

Issue Number:
N/A

## What is the new behavior?

1) This PR covers updating  the device service snap to allow these variables to be set/queried via the configure hook:

- To change the default startup duration use:
sudo snap set edgex-device-modbus startup-duration=n

- To change the default startup interval use:
sudo snap set edgex-device-modbus startup-interval=n

2) The snap version will be in the format "1.1.3-dev.4"

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
N/A

## Are there any specific instructions or things that should be known prior to reviewing?
N/A

## Other information
N/A