### PR TITLE
fix (device services): Remove write of input types

### DIFF
--- a/internal/driver/modbusclient.go
+++ b/internal/driver/modbusclient.go
@@ -93,9 +93,14 @@ func (c *ModbusClient) SetValue(commandInfo interface{}, value []byte) error {
 	var err error
 
 	switch modbusCommandInfo.PrimaryTable {
+	case DISCRETES_INPUT:
+		err = fmt.Errorf("Error: DISCRETES_INPUT is Read-Only..!!")
 
 	case COILS:
 		result, err = c.client.WriteMultipleCoils(uint16(modbusCommandInfo.StartingAddress), modbusCommandInfo.Length, value)
+
+	case INPUT_REGISTERS:
+		err = fmt.Errorf("Error: INPUT_REGISTERS is Read-Only..!!")
 
 	case HOLDING_REGISTERS:
 		if modbusCommandInfo.Length == 1 {

--- a/internal/driver/modbusclient.go
+++ b/internal/driver/modbusclient.go
@@ -93,14 +93,9 @@ func (c *ModbusClient) SetValue(commandInfo interface{}, value []byte) error {
 	var err error
 
 	switch modbusCommandInfo.PrimaryTable {
-	case DISCRETES_INPUT:
-		result, err = c.client.WriteMultipleCoils(uint16(modbusCommandInfo.StartingAddress), modbusCommandInfo.Length, value)
 
 	case COILS:
 		result, err = c.client.WriteMultipleCoils(uint16(modbusCommandInfo.StartingAddress), modbusCommandInfo.Length, value)
-
-	case INPUT_REGISTERS:
-		result, err = c.client.WriteMultipleRegisters(uint16(modbusCommandInfo.StartingAddress), modbusCommandInfo.Length, value)
 
 	case HOLDING_REGISTERS:
 		if modbusCommandInfo.Length == 1 {


### PR DESCRIPTION
fixes: #180; Return error for write requests to read-only input objects

Signed-off-by: Vijay Annamalaisamy <vijayone1708@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://wiki.edgexfoundry.org/display/FA/Contributor%27s+Guide
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?
<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
DISCRETES_INPUT and INPUT_REGISTERS are read only registers but are allowed to be writable in the SetValue function

Issue Number: 180


## What is the new behavior?
Write requests for DISCRETES_INPUT and INPUT_REGISTERS return error from the SetValue function and writing to these registers can never happen.

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## Are there any new imports or modules? If so, what are they used for and why?
No

## Are there any specific instructions or things that should be known prior to reviewing?
No

## Other information
None