### PR TITLE
Feature: Add string type of read and write with modbus protocol

### DIFF
--- a/cmd/res/example/configuration.toml
+++ b/cmd/res/example/configuration.toml
@@ -84,6 +84,6 @@ Type = 'consul'
        Port = '1502'
        UnitID = '1'
   [[DeviceList.AutoEvents]]
-    Frequency = '2s'
+    Frequency = '20s'
     OnChange = false
     Resource = 'ReadString'

--- a/cmd/res/example/configuration.toml
+++ b/cmd/res/example/configuration.toml
@@ -71,3 +71,19 @@ Type = 'consul'
        StopBits = '1'
        Parity = 'N'
        UnitID = '1'
+
+# Pre-define Devices
+[[DeviceList]]
+  Name = 'Modbus TCP Read String'
+  Profile = 'Test.Device.Modbus.String.Profile'
+  Description = 'use for auto read a string value'
+  labels = [ 'modbus TCP' ]
+  [DeviceList.Protocols]
+    [DeviceList.Protocols.modbus-tcp]
+       Address = '0.0.0.0'
+       Port = '1502'
+       UnitID = '1'
+  [[DeviceList.AutoEvents]]
+    Frequency = '2s'
+    OnChange = false
+    Resource = 'ReadString'

--- a/cmd/res/example/modbus.test.device.string.profile.yml
+++ b/cmd/res/example/modbus.test.device.string.profile.yml
@@ -1,0 +1,80 @@
+name: "Test.Device.Modbus.String.Profile"
+manufacturer: "no manufacturer"
+model: "string value type"
+labels:
+  - "no lable"
+description: "this profile is testing  string value type with read and write"
+
+deviceResources:
+  -
+    name: "StringA"
+    description: "no description"
+    attributes:
+      { primaryTable: "INPUT_REGISTERS", startingAddress: "1", stringLength: "1"}
+    properties:
+      value:
+        { type: "STRING", readWrite: "R"}
+      units:
+        { type: "String", readWrite: "R"}
+
+  -
+    name: "StringB"
+    description: "no description"
+    attributes:
+      { primaryTable: "HOLDING_REGISTERS", startingAddress: "15", stringLength: "5"}
+    properties:
+      value:
+        { type: "STRING", readWrite: "RW"}
+      units:
+        { type: "String", readWrite: "R"}
+
+
+
+deviceCommands:
+  -
+    name: "ReadString"
+    get:
+      - { index: "1", operation: "set", deviceResource: "StringA"}
+      - { index: "2", operation: "set", deviceResource: "StringB"}
+  -
+    name: "WriteString"
+    get:
+      - { index: "1", operation: "get", deviceResource: "StringB"}
+    set:
+      - { index: "1", operation: "set", deviceResource: "StringB"}
+
+coreCommands:
+  -
+    name: "ReadString"
+    get:
+      path: "/api/v1/device/{deviceId}/ReadString"
+      responses:
+        - code: "200"
+          description: "Get the Value of String"
+          expectedValues: ["StringA","StringB"]
+        - code: "500"
+          description: "internal server error"
+          expectedValues: []
+  -
+    name: "WriteString"
+    get:
+      path: "/api/v1/device/{deviceId}/WriteString"
+      responses:
+        -
+          code: "200"
+          description: "Get the values of string type"
+          expectedValues: ["StringB"]
+        - code: "500"
+          description: "internal server error"
+          expectedValues: []
+    put:
+      path: "/api/v1/device/{deviceId}/WriteString"
+      parameterNames: ["StringB"]
+      responses:
+        -
+          code: "204"
+          description: "Set the values of string type"
+          expectedValues: []
+        - code: "500"
+          description: "internal server error"
+          expectedValues: []

--- a/internal/driver/constant.go
+++ b/internal/driver/constant.go
@@ -34,6 +34,7 @@ const (
 	// RAW_TYPE define binary data type which read from Modbus device
 	RAW_TYPE = "rawType"
 
+	STR_LENGTH             = "stringLength"
 	SERVICE_STOP_WAIT_TIME = 1
 )
 
@@ -56,5 +57,6 @@ var ValueTypeBitCountMap = map[sdkModel.ValueType]uint16{
 	sdkModel.Float32: 32,
 	sdkModel.Float64: 64,
 
-	sdkModel.Bool: 1,
+	sdkModel.Bool:   1,
+	sdkModel.String: 1,
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
          yes :   test with edgex-ui-go, actions : add a device , and use the stringA and stringB device.
- [x] Docs have been added / updated (for bug fixes / features)
          yes :   file name : (cmd/res/example/modbus.test.device.string.profile.yml)

## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->


## Issue Number:


## What is the new behavior?
add a string type 

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->
      a profile template like :cmd/res/example/modbus.test.device.string.profile.yml
      if add a string device, you must add a attribute of "stingLength" to tell the length of the device address, if not, defalut will be 1.
## Other information
