### PR TITLE
ci: update local docker image names in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,6 @@ docker: $(DOCKERS)
 docker_device_modbus_go:
 	docker build \
 		--label "git_sha=$(GIT_SHA)" \
-		-t edgexfoundry/docker-device-modbus-go:$(GIT_SHA) \
-		-t edgexfoundry/docker-device-modbus-go:$(VERSION)-dev \
+		-t edgexfoundry/device-modbus:$(GIT_SHA) \
+		-t edgexfoundry/device-modbus:$(VERSION)-dev \
 		.


### PR DESCRIPTION
As part of the Ireland release it was decided to remove the docker- in the image prefix and -go in the image suffix.