### PR TITLE
refactor: Update for new service key names and overrides for hyphen to underscore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ WORKDIR /device-modbus-go
 
 COPY . .
 
+RUN go mod tidy
 RUN go mod download
 
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ cmd/device-modbus:
 	$(GOCGO) build $(GOFLAGS) -o $@ ./cmd
 
 test:
+	go mod tidy
 	$(GOCGO) test ./... -coverprofile=coverage.out
 	$(GOCGO) vet ./...
 	gofmt -l .

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	serviceName string = "edgex-device-modbus"
+	serviceName string = "device-modbus"
 )
 
 func main() {

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -29,12 +29,12 @@ Port = 8500
 Type = 'consul'
 
 [Clients]
-  [Clients.edgex-core-data]
+  [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48080
 
-  [Clients.edgex-core-metadata]
+  [Clients.core-metadata]
   Protocol = 'http'
   Host = 'localhost'
   Port = 48081

--- a/go.mod
+++ b/go.mod
@@ -2,12 +2,16 @@ module github.com/edgexfoundry/device-modbus-go
 
 require (
 	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.58
-	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.83
+	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/goburrow/modbus v0.1.0
 	github.com/goburrow/serial v0.1.0 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/stretchr/testify v1.7.0
+)
+
+replace (
+	github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go
 )
 
 go 1.16

--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,13 @@
 module github.com/edgexfoundry/device-modbus-go
 
 require (
-	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.58
+	github.com/edgexfoundry/device-sdk-go/v2 v2.0.0-dev.63
 	github.com/edgexfoundry/go-mod-core-contracts/v2 v2.0.0-dev.90
 	github.com/goburrow/modbus v0.1.0
 	github.com/goburrow/serial v0.1.0 // indirect
 	github.com/hashicorp/go-sockaddr v1.0.1 // indirect
 	github.com/hashicorp/golang-lru v0.5.1 // indirect
 	github.com/stretchr/testify v1.7.0
-)
-
-replace (
-	github.com/edgexfoundry/device-sdk-go/v2 => ../../device-sdk-go
 )
 
 go 1.16


### PR DESCRIPTION
**Dependent on edgexfoundry/device-sdk-go#926**

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/master/.github/Contributing.md

## What is the current behavior?
Service key constants have the edgex- prefix

## Issue Number: #241 & #226


## What is the new behavior?
Service key constants no longer have the edgex- prefix
Hyphen in Overrides are converted to underscore


## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Service key names used in configuration have changed.


## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
