### PR TITLE
refactor: Update to assign and uses new Port Assignments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ COPY --from=builder /device-modbus-go/cmd /
 COPY --from=builder /device-modbus-go/LICENSE /
 COPY --from=builder /device-modbus-go/Attribution.txt /
 
-EXPOSE 49991
+EXPOSE 59901
 
 ENTRYPOINT ["/device-modbus"]
 CMD ["--cp=consul://edgex-core-consul:8500", "--registry", "--confdir=/res"]

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -13,7 +13,7 @@ BootTimeout = 30000
 CheckInterval = '10s'
 Host = 'localhost'
 ServerBindAddr = ''  # blank value defaults to Service.Host value
-Port = 49991
+Port = 59901
 Protocol = 'http'
 StartupMsg = 'device modbus started'
 Timeout = 5000
@@ -32,12 +32,12 @@ Type = 'consul'
   [Clients.core-data]
   Protocol = 'http'
   Host = 'localhost'
-  Port = 48080
+  Port = 59880
 
   [Clients.core-metadata]
   Protocol = 'http'
   Host = 'localhost'
-  Port = 48081
+  Port = 59881
 
 [MessageQueue]
 Protocol = 'redis'


### PR DESCRIPTION
closes 

Signed-off-by: lenny <leonard.goodell@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/master/.github/Contributing.md

## What is the current behavior?
Ports assigned for Core/Supporting services are 408xx range
Device Modbus uses 49991

## Issue Number: #247


## What is the new behavior?
Ports assigned for Core/Supporting services are 588xx range
Device Modbus default port number is now 59901

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [x] Yes
- [ ] No

BREAKING CHANGE: Device Modbus default port number has changed to 59901

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [ ] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
