### PR TITLE
fix: Change "."s in profile name to "-"s

### DIFF
--- a/cmd/res/devices/modbus.test.devices.toml
+++ b/cmd/res/devices/modbus.test.devices.toml
@@ -1,7 +1,7 @@
 # Pre-define Devices
 [[DeviceList]]
   Name = 'Modbus-TCP-test-device'
-  ProfileName = 'Test.Device.Modbus.Profile'
+  ProfileName = 'Test-Device-Modbus-Profile'
   Description = 'This device is a product for monitoring and controlling digital inputs and outputs over a LAN.'
   labels = [ 'Air conditioner','modbus TCP' ]
   [DeviceList.Protocols]
@@ -18,7 +18,7 @@
 
 [[DeviceList]]
   Name = 'Modbus-RTU-test-device'
-  ProfileName = 'Test.Device.Modbus.Profile'
+  ProfileName = 'Test-Device-Modbus-Profile'
   Description = 'This device is a product for monitoring and controlling digital inputs and outputs over a LAN.'
   labels = [ 'Air conditioner','modbus RTU' ]
   [DeviceList.Protocols]

--- a/cmd/res/profiles/modbus.test.device.profile.yml
+++ b/cmd/res/profiles/modbus.test.device.profile.yml
@@ -1,4 +1,4 @@
-name: "Test.Device.Modbus.Profile"
+name: "Test-Device-Modbus-Profile"
 manufacturer: "Cool Automation"
 model: "CoolMasterNet"
 labels:


### PR DESCRIPTION
c## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/master/.github/Contributing.md

## What is the current behavior?
Profile as invalid "." characters in the name

## Issue Number: #267


## What is the new behavior?
"."s in Profile name changed to "-"s

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [x] No

## New Imports
<!-- Are there any new imports or modules? If so, what are they used for and why? -->

- [ ] Yes
- [x] No

## Specific Instructions
<!-- Are there any specific instructions or things that should be known prior to reviewing? -->

## Other information
