### PR TITLE
fix(snap): expose parent directory in device-config plug

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -47,7 +47,6 @@ apps:
 plugs:
   device-config:
     interface: content
-    content: device-config
     target: $SNAP_DATA/config/device-modbus
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -48,7 +48,7 @@ plugs:
   device-config:
     interface: content
     content: device-config
-    target: $SNAP_DATA/config/device-modbus/res
+    target: $SNAP_DATA/config/device-modbus
 
 parts:
   hooks:


### PR DESCRIPTION
This is required to allow providing a whole directory containing configuration files and other directories.

Related to canonical/edgex-config-provider#2

In addition, the redundant content identifier is removed because it is equal to the plug name. When not set, it default to the plug name; see https://snapcraft.io/docs/content-interface

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>
 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
  - Even though the interface target is changed, this is not a breaking change. Because it never used to work as expected and there should be no existing working slot which would be broken by this change.
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
See https://github.com/canonical/edgex-config-provider

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->