### PR TITLE
build(snap): source metadata from central repo

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,17 +1,8 @@
 name: edgex-device-modbus
 base: core20
 license: Apache-2.0
-adopt-info: device-modbus
-summary: Connect data Modbus to EdgeX using device-modbus reference Device Service
-title: EdgeX Modbus Device Service
-description: |
-  The official reference EdgeX device-modbus Device Service built using the 
-  device-sdk-go to interact with Modbus devices. 
-  Initially the daemon in the snap is disabled - a device profile must be
-  provisioned externally with core-metadata or provided to device-modbus inside
-  "$SNAP_DATA/config/device-modbus/res" before starting.
+adopt-info: metadata
 
-# TODO: add armhf when the project supports this
 architectures:
   - build-on: amd64
   - build-on: arm64
@@ -19,7 +10,8 @@ architectures:
 grade: stable
 confinement: strict
 
-# 1.x releases are epoch 1 and Ireland (2.x) is epoch 2
+# 1: <= hanoi
+# 2: >= ireland 
 epoch: 2
 
 slots:
@@ -62,6 +54,7 @@ parts:
       install -DT ./cmd/install/install "$SNAPCRAFT_PART_INSTALL/snap/hooks/install"
 
   device-modbus:
+    after: [metadata]
     source: .
     plugin: make
     build-packages: [git, libzmq3-dev, zip, pkg-config]
@@ -71,13 +64,8 @@ parts:
     override-build: |
       cd $SNAPCRAFT_PART_SRC
 
-      GIT_VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
-      if [ -z "$GIT_VERSION" ]; then
-        GIT_VERSION="0.0.0"
-      fi
-      snapcraftctl set-version ${GIT_VERSION}
-      # this is needed for make build
-      echo $GIT_VERSION > ./VERSION
+      # the version is needed for the build
+      cat ./VERSION
 
       go mod tidy -compat=1.17
       make build
@@ -107,3 +95,27 @@ parts:
   config-common:
     plugin: dump
     source: snap/local/runtime-helpers
+
+  metadata:
+    plugin: nil
+    source: https://github.com/canonical/edgex-snap-metadata.git
+    source-branch: appstream
+    source-depth: 1
+    override-build: |
+      # install the icon at the default internal path
+      install -DT edgex-snap-icon.png \
+        $SNAPCRAFT_PART_INSTALL/meta/gui/icon.png
+      
+      # change to this project's repo to get the version
+      cd $SNAPCRAFT_PROJECT_DIR
+      if git describe ; then
+        VERSION=$(git describe --tags --abbrev=0 | sed 's/v//')
+      else
+        VERSION="0.0.0"
+      fi
+      
+      # write version to file for the build
+      echo $VERSION > ./VERSION
+      # set the version of this snap
+      snapcraftctl set-version $VERSION
+    parse-info: [edgex-device-modbus.metainfo.xml]  


### PR DESCRIPTION
The metadata kept in snapcraft.yaml is obsolete because it is being overridden on the store. This change will allow sourcing the central copy of metadata.

See https://github.com/canonical/edgex-snap-metadata/issues/2

Signed-off-by: Farshid Tavakolizadeh <farshid.tavakolizadeh@canonical.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-mqtt-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

```
# clean and build:
$ snapcraft clean && snapcraft

# unpack the built snap:
$ unsquashfs name.snap

# verify that icon exists:
$ ls squashfs-root/meta/gui/icon.png 
squashfs-root/meta/gui/icon.png

# verify that version, summary and description are included:
$ cat squashfs-root/meta/snap.yaml
...
version: 2.2.0-dev.2
summary: EdgeX Device Modbus
description: |-
  EdgeX Device Modbus is a device service for adding Modbus communication capabilities to EdgeX.
  It supports read/write over both Modbus TCP and Modbus RTU protocols.

  **Snap usage instructions**

  https://github.com/edgexfoundry/device-modbus-go/blob/main/snap/README.md

  **Source code and more info**

  https://github.com/edgexfoundry/device-modbus-go

  **Service usage examples**

  * v1.3: https://docs.edgexfoundry.org/1.3/examples/Ch-ExamplesAddingModbusDevice
  * v2.1: https://docs.edgexfoundry.org/2.1/examples/Ch-ExamplesAddingModbusDevice
  * v2.2: https://docs.edgexfoundry.org/2.2/examples/Ch-ExamplesAddingModbusDevice

  **EdgeX documentation**

  https://docs.edgexfoundry.org

  **Reference platform snap**

  https://snapcraft.io/edgexfoundry
...
```

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->