### PR TITLE
feat: change timeout type from int to time.Duration

### DIFF
--- a/internal/driver/config.go
+++ b/internal/driver/config.go
@@ -9,7 +9,7 @@ package driver
 import (
 	"fmt"
 	"strconv"
-
+	"time"
 	"github.com/edgexfoundry/go-mod-core-contracts/v2/models"
 )
 
@@ -24,9 +24,9 @@ type ConnectionInfo struct {
 	Parity   string
 	UnitID   uint8
 	// Connect & Read timeout(seconds)
-	Timeout int
+	Timeout time.Duration
 	// Idle timeout(seconds) to close the connection
-	IdleTimeout int
+	IdleTimeout time.Duration
 }
 
 func createConnectionInfo(protocols map[string]models.ProtocolProperties) (info *ConnectionInfo, err error) {
@@ -60,6 +60,18 @@ func parseIntValue(properties map[string]string, key string) (int, error) {
 		return 0, fmt.Errorf("protocol config '%s' not exist", key)
 	}
 	val, err := strconv.Atoi(str)
+	if err != nil {
+		return 0, fmt.Errorf("fail to parse protocol config '%s', %v", key, err)
+	}
+	return val, nil
+}
+
+func parseDurationValue(properties map[string]string, key string) (time.Duration, error) {
+	str, ok := properties[key]
+	if !ok {
+		return 0, fmt.Errorf("protocol config '%s' not exist", key)
+	}
+	val, err := time.ParseDuration(str)
 	if err != nil {
 		return 0, fmt.Errorf("fail to parse protocol config '%s', %v", key, err)
 	}
@@ -105,12 +117,12 @@ func createRTUConnectionInfo(rtuProtocol map[string]string) (info *ConnectionInf
 		return nil, fmt.Errorf("invalid parity value, it should be N(None) or O(Odd) or E(Even)")
 	}
 
-	timeout, err := parseIntValue(rtuProtocol, Timeout)
+	timeout, err := parseDurationValue(rtuProtocol, Timeout)
 	if err != nil {
 		return nil, err
 	}
 
-	idleTimeout, err := parseIntValue(rtuProtocol, IdleTimeout)
+	idleTimeout, err := parseDurationValue(rtuProtocol, IdleTimeout)
 	if err != nil {
 		return nil, err
 	}
@@ -153,12 +165,12 @@ func createTcpConnectionInfo(tcpProtocol map[string]string) (info *ConnectionInf
 		return nil, fmt.Errorf("uintID value out of range(0–255). Error: %v", err)
 	}
 
-	timeout, err := parseIntValue(tcpProtocol, Timeout)
+	timeout, err := parseDurationValue(tcpProtocol, Timeout)
 	if err != nil {
 		return nil, err
 	}
 
-	idleTimeout, err := parseIntValue(tcpProtocol, IdleTimeout)
+	idleTimeout, err := parseDurationValue(tcpProtocol, IdleTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/driver/modbusclient.go
+++ b/internal/driver/modbusclient.go
@@ -129,15 +129,15 @@ func NewDeviceClient(connectionInfo *ConnectionInfo) (*ModbusClient, error) {
 	if client.IsModbusTcp {
 		client.TCPClientHandler.Address = fmt.Sprintf("%s:%d", connectionInfo.Address, connectionInfo.Port)
 		client.TCPClientHandler.SlaveId = byte(connectionInfo.UnitID)
-		client.TCPClientHandler.Timeout = time.Duration(connectionInfo.Timeout) * time.Second
-		client.TCPClientHandler.IdleTimeout = time.Duration(connectionInfo.IdleTimeout) * time.Second
+		client.TCPClientHandler.Timeout = time.Duration(connectionInfo.Timeout)
+		client.TCPClientHandler.IdleTimeout = time.Duration(connectionInfo.IdleTimeout)
 		client.TCPClientHandler.Logger = log.New(os.Stdout, "", log.LstdFlags)
 	} else {
 		serialParams := strings.Split(connectionInfo.Address, ",")
 		client.RTUClientHandler.Address = serialParams[0]
 		client.RTUClientHandler.SlaveId = byte(connectionInfo.UnitID)
-		client.RTUClientHandler.Timeout = time.Duration(connectionInfo.Timeout) * time.Second
-		client.RTUClientHandler.IdleTimeout = time.Duration(connectionInfo.IdleTimeout) * time.Second
+		client.RTUClientHandler.Timeout = time.Duration(connectionInfo.Timeout)
+		client.RTUClientHandler.IdleTimeout = time.Duration(connectionInfo.IdleTimeout)
 		client.RTUClientHandler.BaudRate = connectionInfo.BaudRate
 		client.RTUClientHandler.DataBits = connectionInfo.DataBits
 		client.RTUClientHandler.StopBits = connectionInfo.StopBits


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Add a device profile with Timeout and IdleTimeot with valid strings as stated here: [https://pkg.go.dev/time#ParseDuration](https://pkg.go.dev/time#ParseDuration)

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->