### PR TITLE
build: Add option to build Service with NATS Capability

### DIFF
--- a/Attribution.txt
+++ b/Attribution.txt
@@ -224,3 +224,12 @@ https://cs.opensource.google/go/x/sync/+/master:LICENSE
 
 github.com/spf13/cast (MIT) https://github.com/spf13/cast
 https://github.com/spf13/cast/blob/master/LICENSE
+
+github.com/nats-io/nats.go (Apache-2.0) https://github.com/nats-io/nats.go
+https://github.com/nats-io/nats.go/blob/main/LICENSE
+
+github.com/nats-io/nkeys (Apache-2.0) https://github.com/nats-io/nkeys
+https://github.com/nats-io/nkeys/blob/master/LICENSE
+
+github.com/nats-io/nuid (Apache-2.0) https://github.com/nats-io/nuid
+https://github.com/nats-io/nuid/blob/master/LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@
 ARG BASE=golang:1.18-alpine3.16
 FROM ${BASE} AS builder
 
-ARG MAKE='make build'
+ARG ADD_BUILD_TAGS=""
+ARG MAKE="make -e ADD_BUILD_TAGS=$ADD_BUILD_TAGS build"
 
 RUN sed -e 's/dl-cdn[.]alpinelinux.org/dl-4.alpinelinux.org/g' -i~ /etc/apk/repositories
 RUN apk add --update --no-cache make git openssh gcc libc-dev zeromq-dev libsodium-dev

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,14 @@ CGOFLAGS=-ldflags "-linkmode=external -X github.com/edgexfoundry/device-modbus-g
 
 build: $(MICROSERVICES)
 
+build-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging build
+
 tidy:
 	go mod tidy
 
 cmd/device-modbus:
-	$(GOCGO) build $(CGOFLAGS) -o $@ ./cmd
+	$(GOCGO) build -tags "$(ADD_BUILD_TAGS)" $(CGOFLAGS) -o $@ ./cmd
 
 unittest:
 	$(GOCGO) test ./... -coverprofile=coverage.out
@@ -53,10 +56,14 @@ docker: $(DOCKERS)
 
 docker_device_modbus_go:
 	docker build \
+		--build-arg ADD_BUILD_TAGS=$(ADD_BUILD_TAGS) \
 		--label "git_sha=$(GIT_SHA)" \
 		-t edgexfoundry/device-modbus:$(GIT_SHA) \
 		-t edgexfoundry/device-modbus:$(VERSION)-dev \
 		.
+
+docker-nats:
+	make -e ADD_BUILD_TAGS=include_nats_messaging docker
 
 vendor:
 	$(GO) mod vendor

--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 
 ## Overview
 Modbus Micro Service - device service for connecting Modbus devices to EdgeX.
+## Build with NATS Messaging
+Currently, the NATS Messaging capability (NATS MessageBus) is opt-in at build time.
+This means that the published Docker image and Snaps do not include the NATS messaging capability.
+
+The following make commands will build the local binary or local Docker image with NATS messaging
+capability included.
+```makefile
+make build-nats
+make docker-nats
+```
+
+The locally built Docker image can then be used in place of the published Docker image in your compose file.
+See [Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder#gen) `nat-bus` option to generate compose file for NATS and local dev images.
+
 ## Usage
 Users can refer to [the document](https://docs.edgexfoundry.org/2.0/examples/Ch-ExamplesAddingModbusDevice) to learn how to use this device service.
 ## Example Profile and Device

--- a/cmd/res/configuration.toml
+++ b/cmd/res/configuration.toml
@@ -55,16 +55,23 @@ AuthMode = "usernamepassword"  # required for redis messagebus (secure or insecu
 SecretName = "redisdb"
 PublishTopicPrefix = "edgex/events/device" # /<device-profile-name>/<device-name>/<source-name> will be added to this Publish Topic prefix
   [MessageQueue.Optional]
-  # Default MQTT Specific options that need to be here to enable environment variable overrides of them
-  # Client Identifiers
+  # Default MQTT & NATS Specific options that need to be here to enable environment variable overrides of them
   ClientId = "device-modbus"
-  # Connection information
-  Qos = "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
-  KeepAlive = "10" # Seconds (must be 2 or greater)
+  Qos =  "0" # Quality of Sevice values are 0 (At most once), 1 (At least once) or 2 (Exactly once)
+  KeepAlive =  "10" # Seconds (must be 2 or greater)
   Retained = "false"
   AutoReconnect = "true"
   ConnectTimeout = "5" # Seconds
-  SkipCertVerify = "false" # Only used if Cert/Key file or Cert/Key PEMblock are specified  [MessageQueue.Optional]
+  SkipCertVerify = "false"
+  # Default NATS Specific options that need to be here to enable evnironment variable overrides of them
+  Format = "nats"
+  RetryOnFailedConnect = "true"
+  QueueGroup = ""
+  Durable = ""
+  AutoProvision = "true"
+  Deliver = "new"
+  DefaultPubRetryAttempts = "2"
+  Subject = "edgex/#" # Required for NATS Jetstram only for stream autoprovsioning
 
 # Only used when EDGEX_SECURITY_SECRET_STORE=true which is now required for secure Consul
 [SecretStore]


### PR DESCRIPTION
Also updated to latest SDK which brought in more NATS dependencies

Signed-off-by: Leonard Goodell <leonard.goodell@intel.com>

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) **N/A**
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?) 
- [ ] I have opened a PR for the related docs change (if not, why?) **N/A**
  <link to docs PR>

## Testing Instructions
run `make build-nats`
verify see `-tags "include_nats_messaging"  in the Go build line
run `make docker-nats`
verify see `-tags "include_nats_messaging"  in the Go build line

## New Dependency Instructions (If applicable)
New dependencies are from our own go-mod-messaging module. Not new to EdgeX