### PR TITLE
fix: change autoEvents keys to camelCase

### DIFF
--- a/cmd/res/devices/modbus.test.devices.yaml
+++ b/cmd/res/devices/modbus.test.devices.yaml
@@ -16,9 +16,9 @@ deviceList:
         Timeout: 5
         IdleTimeout: 5
     autoEvents:
-      - Interval: 20s
-        OnChange: false
-        SourceName: HVACValues
+      - interval: 20s
+        onChange: false
+        sourceName: HVACValues
   - name: Modbus-RTU-test-device
     profileName: Test-Device-Modbus-Profile
     description: >-
@@ -51,6 +51,6 @@ deviceList:
         Timeout: 5
         IdleTimeout: 5
     autoEvents:
-      - Interval: 20s
-        OnChange: false
-        SourceName: ReadString
+      - interval: 20s
+        onChange: false
+        sourceName: ReadString


### PR DESCRIPTION
The unmarshaller ignores autoEvents fields because of the casing, resulting in the following fatal error: 
`level=ERROR ts=2023-05-08T14:17:09.982416986Z app=device-modbus source=init.go:95 msg="Failed to load devices: request failed, status code: 400, err: {\"apiVersion\":\"v3\",\"message\":\"AddDeviceRequest.Device.AutoEvents[0].Interval field is required; AddDeviceRequest.Device.AutoEvents[0].SourceName field is required\",\"statusCode\":400}\n"`

This PR changes the cases to camelCase to fix the issue, as suggested by @lenny-intel.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->