### PR TITLE
feat: rawType int32 for valueType float64 added

### DIFF
--- a/internal/driver/deviceclient.go
+++ b/internal/driver/deviceclient.go
@@ -160,6 +160,10 @@ func TransformDataBytesToResult(req *models.CommandRequest, dataBytes []byte, co
 			raw := binary.BigEndian.Uint16(dataBytes)
 			res = float64(raw)
 			driver.Logger.Debugf("According to the rawType %s and the value type %s, convert integer %d to float %v ", UINT16, FLOAT64, res, result.ValueToString())
+		case common.ValueTypeInt32:
+			raw := int32(binary.BigEndian.Uint32(swap32BitDataBytes(dataBytes, commandInfo.IsByteSwap, commandInfo.IsWordSwap)))
+			res = float64(raw)
+			driver.Logger.Debugf("According to the rawType %s and the value type %s, convert integer %d to float %v ", INT32, FLOAT64, res, result.ValueToString())
 		}
 	case common.ValueTypeBool:
 		res = false

--- a/internal/driver/deviceclient_test.go
+++ b/internal/driver/deviceclient_test.go
@@ -316,6 +316,33 @@ func TestTransformDataBytesToResult_RawType_UINT16_ValueType_FLOAT64(t *testing.
 	assert.Equal(t, expected, result)
 }
 
+func TestTransformDataBytesToResult_RawType_INT32_ValueType_FLOAT64(t *testing.T) {
+
+	req := models.CommandRequest{
+		DeviceResourceName: "light",
+		Type:               common.ValueTypeFloat64,
+		Attributes: map[string]interface{}{
+			PRIMARY_TABLE:    INPUT_REGISTERS,
+			STARTING_ADDRESS: 10,
+			RAW_TYPE:         INT32,
+		},
+	}
+
+	// Create a command info struct with the appropriate settings
+	commandInfo, err := createCommandInfo(&req)
+	require.NoError(t, err)
+	// Create some test data bytes
+	dataBytes := []byte{0x01, 0x01, 0x01, 0x01}
+	expected := float64(16843009)
+
+	// Call the function being tested
+	commandValue, err := TransformDataBytesToResult(&req, dataBytes, commandInfo)
+	require.NoError(t, err)
+	result, err := commandValue.Float64Value()
+	require.NoError(t, err)
+
+	assert.Equal(t, expected, result)
+}
 func TestTransformCommandValueToDataBytes_INT16(t *testing.T) {
 	req := models.CommandRequest{
 		DeviceResourceName: "light",

--- a/internal/driver/utils.go
+++ b/internal/driver/utils.go
@@ -31,6 +31,8 @@ func normalizeRawType(rawType string) (normalized string, err errors.EdgeX) {
 		normalized = common.ValueTypeUint16
 	case INT16:
 		normalized = common.ValueTypeInt16
+	case INT32:
+		normalized = common.ValueTypeInt32
 	default:
 		return "", errors.NewCommonEdgeX(errors.KindContractInvalid, fmt.Sprintf("the raw type %s is not supported", rawType), nil)
 	}


### PR DESCRIPTION
<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->
It has been added a new rawType (int32) for the valueType float64.
If the PR is approved, a new PR will be uploaded to update the docs properly

https://docs.edgexfoundry.org/3.0/examples/Ch-ExamplesModbusdatatypeconversion/

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
-- TestTransformDataBytesToResult_RawType_INT32_ValueType_FLOAT64 in internal/driver/deviceclient_test.go
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
 [ <link to docs PR>](https://github.com/edgexfoundry/edgex-docs/pull/1179)

## Testing Instructions
<!-- How can the reviewers test your change? -->
The UT mentioned above is one way, additionally, It can be tested using the MODBUS simulator

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->