### PR TITLE
feat: Add new build-noziti and docker-noziti targets into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,9 @@ build: $(MICROSERVICES)
 build-nats:
 	make -e ADD_BUILD_TAGS=include_nats_messaging build
 
+build-noziti:
+	make -e ADD_BUILD_TAGS=no_openziti build
+
 tidy:
 	go mod tidy
 
@@ -74,6 +77,9 @@ docker_device_modbus_go:
 
 docker-nats:
 	make -e ADD_BUILD_TAGS=include_nats_messaging docker
+
+docker-noziti:
+	make -e ADD_BUILD_TAGS=no_openziti docker
 
 vendor:
 	CGO_ENABLED=0 go mod vendor

--- a/README.md
+++ b/README.md
@@ -24,6 +24,16 @@ make docker-nats
 The locally built Docker image can then be used in place of the published Docker image in your compose file.
 See [Compose Builder](https://github.com/edgexfoundry/edgex-compose/tree/main/compose-builder#gen) `nat-bus` option to generate compose file for NATS and local dev images.
 
+## Build without OpenZiti zerotrust
+Currently, the OpenZiti zerotrust capability is opt-out at build time. This means that the published Docker images include the OpenZiti zerotrust capability.
+
+The following make commands will build the local binaries or local Docker images without OpenZiti zerotrust capability.
+
+```makefile
+make build-noziti
+make docker-noziti
+```
+
 ## Usage
 Users can refer to [the document](https://docs.edgexfoundry.org/2.0/examples/Ch-ExamplesAddingModbusDevice) to learn how to use this device service.
 ## Example Profile and Device

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/eclipse/paho.mqtt.golang v1.5.0 // indirect
-	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.8 // indirect
+	github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.9 // indirect
 	github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.4 // indirect
 	github.com/edgexfoundry/go-mod-messaging/v4 v4.0.0-dev.5 // indirect
 	github.com/edgexfoundry/go-mod-registry/v4 v4.0.0-dev.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -72,8 +72,8 @@ github.com/eclipse/paho.mqtt.golang v1.5.0 h1:EH+bUVJNgttidWFkLLVKaQPGmkTUfQQqjO
 github.com/eclipse/paho.mqtt.golang v1.5.0/go.mod h1:du/2qNQVqJf/Sqs4MEL77kR8QTqANF7XU7Fk0aOTAgk=
 github.com/edgexfoundry/device-sdk-go/v4 v4.0.0-dev.7 h1:xajfjK5HybAyyi1rZ1nZ7FHNKMnqRULU4gETx8b1kO0=
 github.com/edgexfoundry/device-sdk-go/v4 v4.0.0-dev.7/go.mod h1:8j7f30tUozHogDsvPwLGaTn6F3MDJb8L2X9q0I3mdac=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.8 h1:uFy9gOVPCLIyYcHcyP8dWBiGPKBvLS+PfaHK9ab/Z9s=
-github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.8/go.mod h1:IvrZ7zaD/0kvN+aAtqdudAPGOa4DprO4SDU3JQhVBUY=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.9 h1:GM0LR1f+fAy79G9GpKvKmqX+owrbaT3fhWT6MNBmEbs=
+github.com/edgexfoundry/go-mod-bootstrap/v4 v4.0.0-dev.9/go.mod h1:IvrZ7zaD/0kvN+aAtqdudAPGOa4DprO4SDU3JQhVBUY=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.4 h1:Bw8Bxoc2LjAfkgWvAQtbeqnAaGPmKiCoAHlHGalhnv4=
 github.com/edgexfoundry/go-mod-configuration/v4 v4.0.0-dev.4/go.mod h1:Jc8kjQTAUYzuHbQzRuVzfPZy3QfJGMQ0rGHOhRit7to=
 github.com/edgexfoundry/go-mod-core-contracts/v4 v4.0.0-dev.5 h1:PHcgm730GAjl8hR5y25OE+YEe6urZhYIcIYGY7TeCWM=


### PR DESCRIPTION
related to https://github.com/edgexfoundry/go-mod-bootstrap/pull/795

To allow to build services without openziti, add new targte build-noziti and docker-noziti into Makefile. Also revise README.md to include such information.

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [ ] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->