### PR TITLE
fix: Fix nil pointer error when sending command

### DIFF
--- a/internal/driver/modbusclient.go
+++ b/internal/driver/modbusclient.go
@@ -155,14 +155,14 @@ func NewDeviceClient(connectionInfo *ConnectionInfo) (*ModbusClient, error) {
 	client.ModbusType = connectionInfo.Protocol
 	switch client.ModbusType {
 	case ProtocolTCP:
-		client.TCPClientHandler.Address = fmt.Sprintf("%s:%d", connectionInfo.Address, connectionInfo.Port)
+		client.TCPClientHandler = *MODBUS.NewTCPClientHandler(fmt.Sprintf("%s:%d", connectionInfo.Address, connectionInfo.Port))
 		client.TCPClientHandler.SlaveID = byte(connectionInfo.UnitID)
 		client.TCPClientHandler.Timeout = time.Duration(connectionInfo.Timeout) * time.Second
 		client.TCPClientHandler.IdleTimeout = time.Duration(connectionInfo.IdleTimeout) * time.Second
 		client.TCPClientHandler.Logger = log.New(os.Stdout, "", log.LstdFlags)
 	case ProtocolRTU:
 		serialParams := strings.Split(connectionInfo.Address, ",")
-		client.RTUClientHandler.Address = serialParams[0]
+		client.RTUClientHandler = *MODBUS.NewRTUClientHandler(serialParams[0])
 		client.RTUClientHandler.SlaveID = byte(connectionInfo.UnitID)
 		client.RTUClientHandler.Timeout = time.Duration(connectionInfo.Timeout) * time.Second
 		client.RTUClientHandler.IdleTimeout = time.Duration(connectionInfo.IdleTimeout) * time.Second
@@ -173,7 +173,7 @@ func NewDeviceClient(connectionInfo *ConnectionInfo) (*ModbusClient, error) {
 		client.RTUClientHandler.Logger = log.New(os.Stdout, "", log.LstdFlags)
 	case ProtocolASCII:
 		serialParams := strings.Split(connectionInfo.Address, ",")
-		client.ASCIIClientHandler.Address = serialParams[0]
+		client.ASCIIClientHandler = *MODBUS.NewASCIIClientHandler(serialParams[0])
 		client.ASCIIClientHandler.SlaveID = byte(connectionInfo.UnitID)
 		client.ASCIIClientHandler.Timeout = time.Duration(connectionInfo.Timeout) * time.Second
 		client.ASCIIClientHandler.IdleTimeout = time.Duration(connectionInfo.IdleTimeout) * time.Second


### PR DESCRIPTION
Assign the Dial func for TCPClientHandler to fix nil pointer error when sending command.

fix #647

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?) not impact
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [ ] I have opened a PR for the related docs change (if not, why?) not impact
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
Run core services and device service to test the get and put command.

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->