### PR TITLE
fix for #666: network issues for one device impacts data gathering of…

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -35,17 +35,28 @@ type Driver struct {
 var concurrentCommandLimit = 100
 
 func (d *Driver) createDeviceClient(info *ConnectionInfo) (DeviceClient, error) {
-	d.clientMutex.Lock()
-	defer d.clientMutex.Unlock()
 	key := info.String()
+
+	d.clientMutex.Lock()
 	c, ok := d.clientMap[key]
+	d.clientMutex.Unlock()
 	if ok {
 		return c, nil
 	}
+
 	c, err := NewDeviceClient(info)
 	if err != nil {
 		driver.Logger.Errorf("create device client failed. err:%v \n", err)
 		return nil, err
+	}
+
+	d.clientMutex.Lock()
+	defer d.clientMutex.Unlock()
+	if existing, ok := d.clientMap[key]; ok {
+		if err = c.CloseConnection(); err != nil {
+			driver.Logger.Warnf("additional client for %s closed with error: %v", key, err)
+		}
+		return existing, nil
 	}
 	d.clientMap[key] = c
 	return c, nil


### PR DESCRIPTION
 network issues for one device impacts data gathering of all devices. Fixes #666 

<!-- Expected Commit Message Description (imported automatically by GitHub) -->
<!-- Must conform to [conventional commits guidelines](https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md) -->
<!-- Expected Commit message must contain Closes/Fixes #IssueNumber statement when there is a related issue -->

<!-- Add additional detailed description of need for change if no related issue -->

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [x] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change (if not, why?)
  <link to docs PR>

## Testing Instructions
<!-- How can the reviewers test your change? -->
You need to have a (mock) device with network issue causing timeouts (for example, say 10s timeout). And a second device without network issues which you are gathering data from frequently, say 1s

## New Dependency Instructions (If applicable)
<!-- Please follow [vetting instructions](https://wiki.edgexfoundry.org/display/FA/Vetting+Process+for+3rd+Party+Dependencies) and place results here -->