### PR TITLE
fix: Clean up connection objects on device removal

### DIFF
--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -51,17 +51,6 @@ func (d *Driver) createDeviceClient(info *ConnectionInfo) (DeviceClient, error) 
 	return c, nil
 }
 
-func (d *Driver) disconnectDeviceClient(info *ConnectionInfo) error {
-	d.clientMutex.Lock()
-	defer d.clientMutex.Unlock()
-	key := info.String()
-	if _, ok := d.clientMap[key]; ok {
-		client := d.clientMap[key]
-		return client.CloseConnection()
-	}
-	return nil
-}
-
 func (d *Driver) removeDeviceClient(info *ConnectionInfo) {
 	d.clientMutex.Lock()
 	defer d.clientMutex.Unlock()
@@ -76,15 +65,6 @@ func (d *Driver) removeDeviceClient(info *ConnectionInfo) {
 		}
 		delete(d.clientMap, key)
 	}
-}
-
-func (d *Driver) DisconnectDevice(deviceName string, protocols map[string]models.ProtocolProperties) error {
-	connectionInfo, err := createConnectionInfo(protocols)
-	if err != nil {
-		driver.Logger.Errorf("Fail to create disconnect device connection info. err:%v \n", err)
-		return err
-	}
-	return d.disconnectDeviceClient(connectionInfo)
 }
 
 // lockAddress mark address is unavailable because real device handle one request at a time


### PR DESCRIPTION
Ensure underlying TCP connections are always closed when devices are removed.
Also added disconnect logic into the API which was previously doing nothing.


**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/device-modbus-go/blob/main/.github/Contributing.md

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] I am not introducing a breaking change (if you are, flag in conventional commit message with `BREAKING CHANGE:` describing the break)
- [x] I am not introducing a new dependency (add notes below if you are)
- [ ] I have added unit tests for the new feature or bug fix (if not, why?)
- [x] I have fully tested (add details below) this the new feature or bug fix (if not, why?)
- [x] I have opened a PR for the related docs change -  NA

## Testing Instructions
Add and remove tcp modbus devices (I recomend using IdleTimeout `-1`). Monitor connection traffic via tcpdump, sometimes it would close sometimes it would not. This PR ensure that the connection is always closed.

## New Dependency Instructions (If applicable)
No new dependency